### PR TITLE
feat: get_region

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ logger = get_logger(__name__)
 logger.debug("message to log")
 ```
 
+## miner_param
+
+### get_region
+Return the region from envvar REGION_OVERRIDE or
+from the contents of /var/pktfwd/region
+
+```python
+from hm_pyhelper.miner_param import get_region
+print(get_region())
+
+> US9155
+```
+
 ## Testing
 
 To run tests:

--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -2,6 +2,10 @@ import os
 import subprocess
 import logging
 import json
+from retry import retry
+from hm_pyhelper.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 def log_stdout_stderr(sp_result):
@@ -95,3 +99,36 @@ def get_mac_address(path):
     except PermissionError as e:
         raise e
     return file.readline().strip().upper()
+
+
+REGION_OVERRIDE_KEY = 'REGION_OVERRIDE'
+REGION_FILEPATH = '/var/pktfwd/region'
+REGION_INVALID_SLEEP_SECONDS = 30
+REGION_FILE_MISSING_SLEEP_SECONDS = 60
+
+
+class MalformedRegionException(Exception):
+    pass
+
+
+@retry(MalformedRegionException, delay=REGION_INVALID_SLEEP_SECONDS, logger=logger) # noqa
+@retry(FileNotFoundError, delay=REGION_FILE_MISSING_SLEEP_SECONDS, logger=logger) # noqa
+def get_region():
+    """
+    Return the region from the environment or parse file created by hm-miner.
+    Retry if region in file is malformed or not found.
+    """
+    region = os.getenv(REGION_OVERRIDE_KEY, False)
+    if region:
+        return region
+
+    logger.debug("No REGION_OVERRIDE defined, will retrieve from miner.")
+    with open(REGION_FILEPATH) as region_file:
+        region = region_file.read().rstrip('\n')
+        logger.debug("Region %s parsed from %s " % (region, REGION_FILEPATH))
+
+        is_region_valid = len(region) > 3
+        if is_region_valid:
+            return region
+
+        raise MalformedRegionException("Region %s is invalid" % region)

--- a/hm_pyhelper/tests/test_get_region.py
+++ b/hm_pyhelper/tests/test_get_region.py
@@ -1,0 +1,15 @@
+from hm_pyhelper.miner_param import get_region, REGION_OVERRIDE_KEY
+import unittest
+from unittest.mock import mock_open, patch
+import os
+
+
+class TestGetRegion(unittest.TestCase):
+    def test_get_region_from_override(self):
+        os.environ[REGION_OVERRIDE_KEY] = 'foo'
+        self.assertEqual(get_region(), 'foo')
+
+    @patch("builtins.open", new_callable=mock_open, read_data="ZZ111\n")
+    def test_get_region_from_miner(self, _):
+        os.environ[REGION_OVERRIDE_KEY] = ''
+        self.assertEqual(get_region(), 'ZZ111')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jsonrpcclient==3.3.6
 requests==2.26.0
+retry==0.9.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.8',
+    version='0.11',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Why**
In the process of refactoring hm-pktfwd. It is not the best place for logic that spans multiple services.

**How**
Port logic from establishing a device's region from hm-pktfwd. Use retry library instead of `while` loops with `sleep`.

**References**
Related to: https://github.com/NebraLtd/hm-pktfwd/issues/45