### PR TITLE
fix: only try to upload if version number changed

### DIFF
--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -82,7 +82,12 @@ jobs:
           name: wheels
           path: ./dist/*
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v2.1
+
       - name: Publish distribution 📦 to Test PyPI
+        if: contains(steps.changed-files.outputs.modified_files, 'setup.py')
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Make building and testing better

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

This is a partial fix for #20 which will avoid trying to upload the file to PyPI when version number hasn't changed in setup.py

This means we can allow other tests to proceed and get a green tick in PRs without having to constantly bump version number.

This will upload build artifacts so the build is still available for testing, just not from PyPI

**References**
<!-- Links to related issues, relevant documentation, etc. -->

#20 