### PR TITLE
Implemented bump2version action

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.12
+current_version = 0.9.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.10.0
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.8.12
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]

--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -77,6 +77,14 @@ jobs:
         run: |
           python -m pip install bump2version
 
+      - name: Assign Git User Email
+        run: |
+          git config --global user.email "mrbump@nebra.com"
+
+      - name: Assign Git User Name
+        run: |
+          git config --global user.name "Mr Bump Nebra"
+
       - name: Bump Version
         run: |
           bump2version minor setup.py

--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -73,6 +73,20 @@ jobs:
         run: |
           python -m pip install build --user
 
+      - name: Install bump2version
+        run: |
+          python -m pip install bump2version
+
+      - name: Bump Version
+        run: |
+          bump2version minor setup.py
+
+      - name: Push Commit from Bump2Version
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+
       - name: Build a binary wheel and a source tarball
         run: |
           python -m build --sdist --wheel --outdir dist/ .

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ setup(
     install_requires=[
         'requests>=2.26.0',
         'jsonrpcclient==3.3.6',
-        'retry==0.9.2',
-        'bump2version'
+        'retry==0.9.2'
     ],
     project_urls={
         "Bug Tracker": "https://github.com/NebraLtd/hm-pyhelper/issues",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.8.12',
+    version='0.9.0',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.9.0',
+    version='0.10.0',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     install_requires=[
         'requests>=2.26.0',
         'jsonrpcclient==3.3.6',
-        'retry==0.9.2'
+        'retry==0.9.2',
+        'bump2version'
     ],
     project_urls={
         "Bug Tracker": "https://github.com/NebraLtd/hm-pyhelper/issues",


### PR DESCRIPTION
**Why**
Duplicate versions prevent pushing the package live on TestPyPi as it doesn't overwrite the previous package.

**How**
Using Bump2Version will automatically bump up the minor version and do a commit with new git tags. 

Github Action New Steps:
- Install Bump2Version
- Run Bump2Version to update the version in setup.py and .bumpversion.cfg
- Bump2Version creates a git tag and commits the files
- Using ad-m/push action I push the latest commit 
