### PR TITLE
Version bump should only happen on master

### DIFF
--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -88,12 +88,14 @@ jobs:
       - name: Bump Version
         run: |
           bump2version minor setup.py
+        if: github.ref == 'refs/heads/master'
 
       - name: Push Commit from Bump2Version
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
+        if: github.ref == 'refs/heads/master'
 
       - name: Build a binary wheel and a source tarball
         run: |
@@ -109,7 +111,7 @@ jobs:
         uses: tj-actions/changed-files@v2.1
 
       - name: Publish distribution 📦 to Test PyPI
-        if: contains(steps.changed-files.outputs.modified_files, 'setup.py')
+        if: github.ref == 'refs/heads/master'
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Bump Version
         run: |
-          bump2version minor setup.py
+          bump2version patch setup.py
         if: github.ref == 'refs/heads/master'
 
       - name: Push Commit from Bump2Version


### PR DESCRIPTION
**Why**
Version bump is happening on any branch, this means any push on a subbranch when testing will result in the version incrementing and might result in merge conflicts and also different versions across the whole project

**How**
Added a master branch if check to each job involving bumping the version and publishing the package, this should now avoid bumping the version on any sub-branch and rely on the master branch
