### PR TITLE
fix: add ipc dependency to setup.py

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.11.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     install_requires=[
         'requests>=2.26.0',
         'jsonrpcclient==3.3.6',
-        'retry==0.9.2'
+        'retry==0.9.2',
+        'posix-ipc==1.0.5'
     ],
     project_urls={
         "Bug Tracker": "https://github.com/NebraLtd/hm-pyhelper/issues",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.10.0',
+    version='0.11.0',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Why**
`@ecc_lock` decorator missing posix-ipc dependency when invoked from a project that adds hm-pyhelper as a dependency. This is causing [hm-diag#198](https://github.com/NebraLtd/hm-diag/pull/198) to [fail](https://github.com/NebraLtd/hm-diag/runs/4086289993?check_suite_focus=true).

**How**
@posterzh I haven't tested that this really does fix the underlying issue, but I believe it does. Can you verify?

**References**
Fixes: https://github.com/NebraLtd/hm-pyhelper/pull/46
