### PR TITLE
feat: add Diagnostic and DiagnosticsReport

### DIFF
--- a/hm_pyhelper/diagnostics/__init__.py
+++ b/hm_pyhelper/diagnostics/__init__.py
@@ -1,0 +1,2 @@
+from hm_pyhelper.diagnostics.diagnostics_report import DiagnosticsReport  # noqa F401
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic  # noqa F401

--- a/hm_pyhelper/diagnostics/diagnostic.py
+++ b/hm_pyhelper/diagnostics/diagnostic.py
@@ -1,0 +1,17 @@
+class Diagnostic():
+    """
+    Pseudo-interface class that should be extended in order to add
+    a type of diagnostic reading to a DiagnosticReport.
+    """
+
+    def __init__(self, key, friendly_key):
+        """
+        key - Key of relevant value in diagnostics_report dictionary
+        friendly_key - Same as key but a human_friendly_snake_case
+                        version. To replace key eventually.
+        """
+        self.key = key
+        self.friendly_key = friendly_key
+
+    def perform_test(self, diagnostics_report):
+        raise Exception("Should be implemented by extending class")

--- a/hm_pyhelper/diagnostics/diagnostics_report.py
+++ b/hm_pyhelper/diagnostics/diagnostics_report.py
@@ -1,0 +1,99 @@
+import json
+
+# Name of key in diagnostics containing meta-information about
+# the overall state of the miner.
+DIAGNOSTICS_PASSED_KEY = 'diagnostics_passed'
+
+# Name of key containing an array of all the diagnostics
+# that are considered to be errors.
+DIAGNOSTICS_ERRORS_KEY = 'errors'
+
+
+class DiagnosticsReport(dict):
+    def __init__(self, diagnostics=[], **kwargs):
+        """
+        Intended to be used for constructing a DiagnosticsReport
+        manually, or deserializing from JSON.
+
+        When constructing manually, use this format:
+            diagnostics = [
+                ExampleDiagnostic()
+            ]
+            diagnostics_report = DiagnosticsReport(diagnostics)
+
+        When deserializing from JSON string:
+            report_json_str = '{"diagnostics_passed": false,
+                                "errors": ["blah"], "ECC": false}'
+            report = DiagnosticsReport.from_json_str(report_json_str)
+        """
+        super(DiagnosticsReport, self).__init__(kwargs)
+
+        if DIAGNOSTICS_PASSED_KEY not in self:
+            self.__setitem__(DIAGNOSTICS_PASSED_KEY, False)
+
+        if DIAGNOSTICS_ERRORS_KEY not in self:
+            self.__setitem__(DIAGNOSTICS_ERRORS_KEY, [])
+        self.diagnostics = diagnostics
+
+    def passed(self):
+        return self[DIAGNOSTICS_PASSED_KEY]
+
+    def set_passed(self, passed):
+        self.__setitem__(DIAGNOSTICS_PASSED_KEY, passed)
+
+    def append_error(self, key):
+        self.__getitem__(DIAGNOSTICS_ERRORS_KEY).append(key)
+
+    def get_errors(self):
+        return self[DIAGNOSTICS_ERRORS_KEY]
+
+    def perform_diagnostics(self):
+        self.__setitem__(DIAGNOSTICS_PASSED_KEY, True)
+        for diagnostic in self.diagnostics:
+            diagnostic.perform_test(self)
+
+    def record_result(self, result, diagnostic):
+        """
+        Add the result to both key and friendly name, until key
+        is deprecated.
+        """
+        self.__setitem__(diagnostic.key, result)
+        # The current keys are terse. Let's migrate to human friendly ones.
+        self.__setitem__(diagnostic.friendly_key, result)
+
+    def record_failure(self, msg_or_exception, diagnostic):
+        """
+        Set the overall diagnostics status to failure and add this error
+        to the list.
+        """
+        # If one test fails, then the overall state is a failure
+        self.set_passed(False)
+
+        # Add the failing key to list of errors
+        self.append_error(diagnostic.key)
+
+        # Provide additional details, like error message
+        record_failure_as = msg_or_exception
+        # Don't stringify bools
+        if not isinstance(msg_or_exception, bool):
+            record_failure_as = str(record_failure_as)
+        self.record_result(record_failure_as, diagnostic)
+
+    def get_report_subset(self, keys_to_extract):
+        return {key: self.__getattribute__(key) for key in keys_to_extract}
+
+    def get_error_messages(self):
+        def get_error_message(key):
+            return "%s Error: %s" % (key, self.__getitem__(key))
+
+        error_messages = map(get_error_message, self.get_errors())
+        return ("\n").join(error_messages)
+
+    @staticmethod
+    def from_json_str(json_str):
+        report_dict = json.loads(json_str)
+        return DiagnosticsReport(report_dict)
+
+    @staticmethod
+    def from_json_dict(report_dict):
+        return DiagnosticsReport(**report_dict)

--- a/hm_pyhelper/exceptions.py
+++ b/hm_pyhelper/exceptions.py
@@ -4,3 +4,7 @@ class MalformedRegionException(Exception):
 
 class SPIUnavailableException(Exception):
     pass
+
+
+class ECCMalfunctionException(Exception):
+    pass

--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -5,7 +5,7 @@ from retry import retry
 from hm_pyhelper.interprocess_lock import ecc_lock
 from hm_pyhelper.logger import get_logger
 from hm_pyhelper.exceptions import MalformedRegionException, \
-    SPIUnavailableException
+    SPIUnavailableException, ECCMalfunctionException
 from hm_pyhelper.hardware_definitions import is_rockpi
 
 
@@ -37,15 +37,17 @@ def run_gateway_mfr(args):
             'gateway_mfr response stdout: %s' % run_gateway_mfr_result.stdout)
         LOGGER.info(
             'gateway_mfr response stderr: %s' % run_gateway_mfr_result.stderr)
-    except subprocess.CalledProcessError:
-        LOGGER.error("gateway_mfr exited with a non-zero status")
-        return False
+    except subprocess.CalledProcessError as e:
+        err_str = "gateway_mfr exited with a non-zero status"
+        LOGGER.exception(err_str)
+        raise ECCMalfunctionException(err_str).with_traceback(e.__traceback__)
 
     try:
         return json.loads(run_gateway_mfr_result.stdout)
-    except json.JSONDecodeError:
-        LOGGER.error("Unable to parse JSON from gateway_mfr")
-    return False
+    except json.JSONDecodeError as e:
+        err_str = "Unable to parse JSON from gateway_mfr"
+        LOGGER.exception(err_str)
+        raise ECCMalfunctionException(err_str).with_traceback(e.__traceback__)
 
 
 def get_public_keys_rust():

--- a/hm_pyhelper/tests/test_diagnostic_report.py
+++ b/hm_pyhelper/tests/test_diagnostic_report.py
@@ -1,0 +1,57 @@
+import unittest
+import json
+
+from hm_pyhelper.diagnostics import Diagnostic
+from hm_pyhelper.diagnostics import DiagnosticsReport
+from hm_pyhelper.diagnostics.diagnostics_report import \
+                                    DIAGNOSTICS_PASSED_KEY, \
+                                    DIAGNOSTICS_ERRORS_KEY
+
+
+class TestDiagnostic(unittest.TestCase):
+    def test_record_result(self):
+        diagnostic = Diagnostic('key', 'friendly_name')
+        diagnostics_report = DiagnosticsReport()
+        diagnostics_report.record_result('foo', diagnostic)
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'key': 'foo',
+            'friendly_name': 'foo'
+        })
+
+    def test_record_failure(self):
+        diagnostic = Diagnostic('key', 'friendly_name')
+        diagnostics_report = DiagnosticsReport()
+        diagnostics_report.record_failure('foo', diagnostic)
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['key'],
+            'key': 'foo',
+            'friendly_name': 'foo'
+        })
+
+    def test_deserialization(self):
+        report_str = '{"diagnostics_passed": false, "errors": ["ECC"], "ECC": false, "foo": "bar"}'  # noqa E501
+        report_dict = json.loads(report_str)
+        diagnostics_report = DiagnosticsReport(**report_dict)
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            'ECC': False,
+            'foo': 'bar'
+        })
+
+    def test_get_error_messages(self):
+        diagnostic1 = Diagnostic('key1', 'friendly_name')
+        diagnostic2 = Diagnostic('key2', 'friendly_name')
+        diagnostics_report = DiagnosticsReport()
+        diagnostics_report.record_failure('Error1', diagnostic1)
+        diagnostics_report.record_failure('Error2', diagnostic2)
+
+        actual_msgs = diagnostics_report.get_error_messages()
+        expected_msgs = "key1 Error: Error1\nkey2 Error: Error2"
+        self.assertEqual(actual_msgs, expected_msgs)


### PR DESCRIPTION
**Why**
Instead of operating on raw Python `dict`s to communicate diagnostics state, we should use an abstraction with an API that makes it clear how to interact with. For example, we don't want failed diagnostics to throw an exception, but instead write information to the corresponding key of the diagnostic output.

**How**
Introduced Diagnostic and DiagnosticsReport classes to be used by hm-diag and hm-pyhelper.
Also changes the error signaling of `get_gateway_mfr_test_result` so that it can be handled more cleanly in hm-diag.


**References**

- Related to: https://github.com/NebraLtd/hm-diag/issues/181
- Related to: https://github.com/NebraLtd/Hotspot-Production-Tool/issues/9
- Related to: https://github.com/NebraLtd/hm-diag/issues/204