### PR TITLE
Make lock_ecc() decorator forward the exception correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ except ResourceBusyError:
 ```
 
 ### `@lock_ecc` decorator
-`@lock_ecc(timeout=DEFAULT_TIMEOUT, raise_exception=False):`
+`@lock_ecc(timeout=DEFAULT_TIMEOUT, raise_resource_busy_exception=True):`
 
 This is the convenient decorator wrapping around the `LockSingleton`.
   - timeout: timeout value. DEFAULT_TIMEOUT = 2 seconds.
-  - raise_exception: set True to raise exception in case of timeout or some error, otherwise just log the error msg
+  - raise_resource_busy_exception: set True to raise exception in case of timeout or some error, otherwise just log the error msg
 
 Usage
 ```

--- a/hm_pyhelper/lock_singleton.py
+++ b/hm_pyhelper/lock_singleton.py
@@ -34,12 +34,13 @@ class ResourceBusyError(Exception):
     pass
 
 
-def lock_ecc(timeout=DEFAULT_TIMEOUT, raise_exception=False):
+def lock_ecc(timeout=DEFAULT_TIMEOUT, raise_resource_busy_exception=True):
     """
     Returns a decorator that locks the ECC.
 
     timeout: timeout value. DEFAULT_TIMEOUT = 2 seconds.
-    raise_exception: set True to raise exception in case of timeout and error.
+    raise_resource_busy_exception: set True to raise exception
+                    in case of lock acquire timeout and error.
                     Otherwise just log the error msg
     """
 
@@ -64,7 +65,7 @@ def lock_ecc(timeout=DEFAULT_TIMEOUT, raise_exception=False):
                 return value
             except ResourceBusyError as ex:
                 LOGGER.error("ECC is busy now.")
-                if raise_exception:
+                if raise_resource_busy_exception:
                     raise ex
             except Exception as ex:
                 raise ex

--- a/hm_pyhelper/lock_singleton.py
+++ b/hm_pyhelper/lock_singleton.py
@@ -52,16 +52,22 @@ def lock_ecc(timeout=DEFAULT_TIMEOUT, raise_exception=False):
                 # try to acquire the ECC resource or may raise an exception
                 lock.acquire(timeout=timeout)
 
-                value = func(*args, **kwargs)
+                try:
+                    value = func(*args, **kwargs)
+                except Exception as ex:
+                    lock.release()
+                    raise ex
 
                 # release the resource
                 lock.release()
 
                 return value
-            except Exception as ex:
+            except ResourceBusyError as ex:
                 LOGGER.error("ECC is busy now.")
                 if raise_exception:
                     raise ex
+            except Exception as ex:
+                raise ex
 
         return wrapper_lock_ecc
 

--- a/hm_pyhelper/tests/test_lock_singleton.py
+++ b/hm_pyhelper/tests/test_lock_singleton.py
@@ -136,9 +136,9 @@ class TestLockSingleton(unittest.TestCase):
     def test_lock_ecc_timeout(self):
         @lock_ecc()
         def slow_task():
-            sleep(0.1)
+            sleep(0.01)
 
-        @lock_ecc(timeout=0.01, raise_exception=True)
+        @lock_ecc(timeout=0.001, raise_resource_busy_exception=True)
         def lock_with_timeout():
             pass
 

--- a/hm_pyhelper/tests/test_lock_singleton.py
+++ b/hm_pyhelper/tests/test_lock_singleton.py
@@ -181,3 +181,18 @@ class TestLockSingleton(unittest.TestCase):
         # Wait to finish
         fast_thread.join()
         slow_thread.join()
+
+    def test_lock_ecc_forward_exception(self):
+        @lock_ecc()
+        def faulty_task():
+            print("Starting the faulty task...")
+            sleep(0.001)
+            raise Exception("Intended faulty occurred!")
+
+        expected_exception = False
+        try:
+            faulty_task()
+        except Exception:
+            expected_exception = True
+
+        self.assertTrue(expected_exception)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.11.2',
+    version='0.11.3',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Why**
Make lock_ecc() decorator forward the exception correctly.

**How**
- Distinguish the exception between the ECC_BUSY_ERROR and the internal exception that comes from the original method.
- Release the acquired lock when the internal exception occurs.

**References**
https://github.com/NebraLtd/hm-pyhelper/pull/46
