### PR TITLE
Removed all references to bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,0 @@
-[bumpversion]
-current_version = 0.11.8
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]

--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -70,24 +70,6 @@ jobs:
         run: |
           python -m pip install build --user
 
-      - name: Install bump2version
-        run: |
-          python -m pip install bump2version
-        if: github.ref == 'refs/heads/master'
-
-      - name: Assign Git User Email
-        run: |
-          git config --global user.email "mrbump@nebra.com"
-
-      - name: Assign Git User Name
-        run: |
-          git config --global user.name "Mr Bump Nebra"
-
-      - name: Bump Version
-        run: |
-          bump2version patch setup.py
-        if: github.ref == 'refs/heads/master'
-
       - name: Build a binary wheel and a source tarball
         run: |
           python -m build --sdist --wheel --outdir dist/ .
@@ -107,24 +89,3 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
         if: github.ref == 'refs/heads/master'
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [build-n-publish]
-    if: github.ref == 'refs/heads/master'
-    steps:
-    - uses: actions/checkout@master
-    - name: Create release
-      uses: Roang-zero1/github-create-release-action@master
-      with:
-        version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Create GitHub release
-      uses: Roang-zero1/github-upload-release-artifacts-action@master
-      with:
-        args: '[
-        , ./dist/*
-        ]'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.11.8',
+    version='0.11.10',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Why**
We are moving away from bump2version and implementing another solution from [here](https://github.com/NebraLtd/hm-pyhelper/issues/20)

**How**
Removed all references to bump2version in the git workflow
