### PR TITLE
fix: correct order for extend commands

### DIFF
--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -25,11 +25,12 @@ def run_gateway_mfr(args):
     gateway_mfr_path = os.path.join(direct_path, 'gateway_mfr')
 
     command = [gateway_mfr_path]
-    command.extend(args)
 
     if is_rockpi():
         extra_args = ['--path', '/dev/i2c-7']
         command.extend(extra_args)
+
+    command.extend(args)
 
     try:
         run_gateway_mfr_result = subprocess.run(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.11.10',
+    version='0.11.11',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Support rockpi

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

`--path /dev/i2c-7` for rockpi needs to come before the command or it will fail

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Relates-to: #67
Relates-to: https://github.com/NebraLtd/hm-diag/issues/237#issuecomment-974694244