### PR TITLE
feat(hardware definitons): add FCC and IC fields

### DIFF
--- a/hm_pyhelper/hardware_definitions.py
+++ b/hm_pyhelper/hardware_definitions.py
@@ -41,7 +41,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': ['2AZDM-HNTIN'],
         'CONTAINS_FCC_IDS': ['2AHRD-EPN8531', '2AB8JCSR40', '2ARPP-GL5712UX'],
-        'ICC_IDS': ['27187-HNTIN']
+        'IC_IDS': ['27187-HNTIN']
         },
 
     # Nebra Indoor Hotspot, Old identifier
@@ -58,7 +58,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': ['2AZDM-HNTIN'],
         'CONTAINS_FCC_IDS': ['2AHRD-EPN8531', '2AB8JCSR40', '2ARPP-GL5712UX'],
-        'ICC_IDS': ['27187-HNTIN']
+        'IC_IDS': ['27187-HNTIN']
         },
 
     # Nebra Outdoor Hotspot Gen1
@@ -76,7 +76,7 @@ variant_definitions = {
         'FCC_IDS': ['2AZDM-HNTOUT'],
         'CONTAINS_FCC_IDS': ['2ARPP-GL5712UX', '2AZDM-CSR8510',
                              'XMR201903EG25G', '2AZDM-WIFIRP'],
-        'ICC_IDS': ['27187-HNTOUT']
+        'IC_IDS': ['27187-HNTOUT']
         },
 
     # Nebra Outdoor Hotspot Old Identifier
@@ -94,7 +94,7 @@ variant_definitions = {
         'FCC_IDS': ['2AZDM-HNTOUT'],
         'CONTAINS_FCC_IDS': ['2ARPP-GL5712UX', '2AZDM-CSR8510',
                              'XMR201903EG25G', '2AZDM-WIFIRP'],
-        'ICC_IDS': ['27187-HNTOUT']
+        'IC_IDS': ['27187-HNTOUT']
         },
 
     # Nebra Pi 0 Light Hotspot SPI Ethernet
@@ -111,7 +111,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': ['2AZDM-HNTLGT'],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': ['27187-HNTLGT']
+        'IC_IDS': ['27187-HNTLGT']
         },
 
     # Nebra Pi 0 Light Hotspot USB Ethernet
@@ -128,7 +128,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': ['2AZDM-HNTLGT'],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': ['27187-HNTLGT']
+        'IC_IDS': ['27187-HNTLGT']
         },
 
     # Nebra Beaglebone Light Hotspot
@@ -145,7 +145,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Nebra Pocket Beagle Light Hotspot
@@ -162,7 +162,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Nebra Hotspot HAT ROCK Pi 4 Indoor
@@ -181,7 +181,7 @@ variant_definitions = {
         'GPIO_PIN_BUTTON': 16,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Nebra Hotspot HAT ROCK Pi 4 Outdoor
@@ -200,7 +200,7 @@ variant_definitions = {
         'GPIO_PIN_BUTTON': 16,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Nebra Hotspot HAT RPi 3/4 Full
@@ -217,7 +217,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Nebra Hotspot HAT RPi Light
@@ -234,7 +234,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Nebra Hotspot HAT Tinkerboard 1
@@ -251,7 +251,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Nebra Hotspot HAT Tinkerboard 2
@@ -268,7 +268,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # RAKwireless Hotspot Miner
@@ -284,7 +284,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Helium Hotspot
@@ -300,7 +300,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # SenseCAP M1 Hotspot
@@ -316,7 +316,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # DIY Pi Supply Hotspot HAT
@@ -332,7 +332,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         },
 
     # Nebra Indoor Hotspot
@@ -348,6 +348,6 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'ICC_IDS': []
+        'IC_IDS': []
         }
 }

--- a/hm_pyhelper/hardware_definitions.py
+++ b/hm_pyhelper/hardware_definitions.py
@@ -41,7 +41,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': ['2AZDM-HNTIN'],
         'CONTAINS_FCC_IDS': ['2AHRD-EPN8531', '2AB8JCSR40', '2ARPP-GL5712UX'],
-        'IC_IDS': ['27187-HNTIN']
+        'IC_IDS': ['27187-HNTIN'],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Indoor Hotspot, Old identifier
@@ -58,7 +59,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': ['2AZDM-HNTIN'],
         'CONTAINS_FCC_IDS': ['2AHRD-EPN8531', '2AB8JCSR40', '2ARPP-GL5712UX'],
-        'IC_IDS': ['27187-HNTIN']
+        'IC_IDS': ['27187-HNTIN'],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Outdoor Hotspot Gen1
@@ -76,7 +78,8 @@ variant_definitions = {
         'FCC_IDS': ['2AZDM-HNTOUT'],
         'CONTAINS_FCC_IDS': ['2ARPP-GL5712UX', '2AZDM-CSR8510',
                              'XMR201903EG25G', '2AZDM-WIFIRP'],
-        'IC_IDS': ['27187-HNTOUT']
+        'IC_IDS': ['27187-HNTOUT'],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Outdoor Hotspot Old Identifier
@@ -94,7 +97,8 @@ variant_definitions = {
         'FCC_IDS': ['2AZDM-HNTOUT'],
         'CONTAINS_FCC_IDS': ['2ARPP-GL5712UX', '2AZDM-CSR8510',
                              'XMR201903EG25G', '2AZDM-WIFIRP'],
-        'IC_IDS': ['27187-HNTOUT']
+        'IC_IDS': ['27187-HNTOUT'],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Pi 0 Light Hotspot SPI Ethernet
@@ -109,9 +113,10 @@ variant_definitions = {
         'ECCOB': True,
         'TYPE': 'Full',
         'CELLULAR': False,
-        'FCC_IDS': ['2AZDM-HNTLGT'],
-        'CONTAINS_FCC_IDS': [],
-        'IC_IDS': ['27187-HNTLGT']
+        'FCC_IDS': ['2AZDM-HNTLGTMC'],
+        'CONTAINS_FCC_IDS': ['2ABCB-RPI0W', '2ARPP-GL5712UX'],
+        'IC_IDS': ['27187-HNTLGTMC'],
+        'CONTAINS_IC_IDS': ['20953-RPI0W']
         },
 
     # Nebra Pi 0 Light Hotspot USB Ethernet
@@ -126,9 +131,10 @@ variant_definitions = {
         'ECCOB': True,
         'TYPE': 'Full',
         'CELLULAR': False,
-        'FCC_IDS': ['2AZDM-HNTLGT'],
+        'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': ['27187-HNTLGT']
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Beaglebone Light Hotspot
@@ -145,7 +151,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Pocket Beagle Light Hotspot
@@ -162,7 +169,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Hotspot HAT ROCK Pi 4 Indoor
@@ -179,9 +187,10 @@ variant_definitions = {
         'CELLULAR': False,
         'GPIO_PIN_LED': 18,
         'GPIO_PIN_BUTTON': 16,
-        'FCC_IDS': [],
-        'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'FCC_IDS': ['2AZDM-HHRK4'],
+        'CONTAINS_FCC_IDS': ['2ARPP-GL5712UX', '2A3PA-ROCKPI4'],
+        'IC_IDS': ['27187-HHRK4'],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Hotspot HAT ROCK Pi 4 Outdoor
@@ -198,9 +207,12 @@ variant_definitions = {
         'CELLULAR': True,
         'GPIO_PIN_LED': 18,
         'GPIO_PIN_BUTTON': 16,
-        'FCC_IDS': [],
-        'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'FCC_IDS': ['2AZDM-HHRK4-OUT'],
+        'CONTAINS_FCC_IDS': ['2ARPP-GL5712UX',
+                             '2A3PA-ROCKPI4',
+                             'XMR201903EG25G'],
+        'IC_IDS': ['27187-HHRK4-OUT'],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Hotspot HAT RPi 3/4 Full
@@ -217,7 +229,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Hotspot HAT RPi Light
@@ -234,7 +247,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Hotspot HAT Tinkerboard 1
@@ -251,7 +265,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Hotspot HAT Tinkerboard 2
@@ -268,7 +283,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # RAKwireless Hotspot Miner
@@ -284,7 +300,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # Helium Hotspot
@@ -300,7 +317,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # SenseCAP M1 Hotspot
@@ -316,7 +334,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # DIY Pi Supply Hotspot HAT
@@ -332,7 +351,8 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         },
 
     # Nebra Indoor Hotspot
@@ -348,6 +368,7 @@ variant_definitions = {
         'CELLULAR': False,
         'FCC_IDS': [],
         'CONTAINS_FCC_IDS': [],
-        'IC_IDS': []
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
         }
 }

--- a/hm_pyhelper/hardware_definitions.py
+++ b/hm_pyhelper/hardware_definitions.py
@@ -38,7 +38,10 @@ variant_definitions = {
         'BUTTON': 26,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': ['2AZDM-HNTIN'],
+        'CONTAINS_FCC_IDS': ['2AHRD-EPN8531', '2AB8JCSR40', '2ARPP-GL5712UX'],
+        'ICC_IDS': ['27187-HNTIN']
         },
 
     # Nebra Indoor Hotspot, Old identifier
@@ -52,7 +55,10 @@ variant_definitions = {
         'BUTTON': 26,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': ['2AZDM-HNTIN'],
+        'CONTAINS_FCC_IDS': ['2AHRD-EPN8531', '2AB8JCSR40', '2ARPP-GL5712UX'],
+        'ICC_IDS': ['27187-HNTIN']
         },
 
     # Nebra Outdoor Hotspot Gen1
@@ -66,7 +72,11 @@ variant_definitions = {
         'BUTTON': 24,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': True
+        'CELLULAR': True,
+        'FCC_IDS': ['2AZDM-HNTOUT'],
+        'CONTAINS_FCC_IDS': ['2ARPP-GL5712UX', '2AZDM-CSR8510',
+                             'XMR201903EG25G', '2AZDM-WIFIRP'],
+        'ICC_IDS': ['27187-HNTOUT']
         },
 
     # Nebra Outdoor Hotspot Old Identifier
@@ -80,7 +90,11 @@ variant_definitions = {
         'BUTTON': 24,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': True
+        'CELLULAR': True,
+        'FCC_IDS': ['2AZDM-HNTOUT'],
+        'CONTAINS_FCC_IDS': ['2ARPP-GL5712UX', '2AZDM-CSR8510',
+                             'XMR201903EG25G', '2AZDM-WIFIRP'],
+        'ICC_IDS': ['27187-HNTOUT']
         },
 
     # Nebra Pi 0 Light Hotspot SPI Ethernet
@@ -94,8 +108,12 @@ variant_definitions = {
         'BUTTON': 23,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': ['2AZDM-HNTLGT'],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': ['27187-HNTLGT']
         },
+
     # Nebra Pi 0 Light Hotspot USB Ethernet
     'NEBHNT-LGT-ZX': {
         'FRIENDLY': 'Nebra Pi 0 Light Hotspot XE',
@@ -107,7 +125,10 @@ variant_definitions = {
         'BUTTON': 23,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': ['2AZDM-HNTLGT'],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': ['27187-HNTLGT']
         },
 
     # Nebra Beaglebone Light Hotspot
@@ -121,7 +142,10 @@ variant_definitions = {
         'BUTTON': 30,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Nebra Pocket Beagle Light Hotspot
@@ -135,7 +159,10 @@ variant_definitions = {
         'BUTTON': 30,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Nebra Hotspot HAT ROCK Pi 4 Indoor
@@ -151,7 +178,10 @@ variant_definitions = {
         'TYPE': 'Full',
         'CELLULAR': False,
         'GPIO_PIN_LED': 18,
-        'GPIO_PIN_BUTTON': 16
+        'GPIO_PIN_BUTTON': 16,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Nebra Hotspot HAT ROCK Pi 4 Outdoor
@@ -167,7 +197,10 @@ variant_definitions = {
         'TYPE': 'Full',
         'CELLULAR': True,
         'GPIO_PIN_LED': 18,
-        'GPIO_PIN_BUTTON': 16
+        'GPIO_PIN_BUTTON': 16,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Nebra Hotspot HAT RPi 3/4 Full
@@ -181,7 +214,10 @@ variant_definitions = {
         'BUTTON': 23,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Nebra Hotspot HAT RPi Light
@@ -195,7 +231,10 @@ variant_definitions = {
         'BUTTON': 23,
         'ECCOB': True,
         'TYPE': 'Light',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Nebra Hotspot HAT Tinkerboard 1
@@ -209,7 +248,10 @@ variant_definitions = {
         'BUTTON': 162,
         'ECCOB': True,
         'TYPE': 'Light',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Nebra Hotspot HAT Tinkerboard 2
@@ -223,7 +265,10 @@ variant_definitions = {
         'BUTTON': 162,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # RAKwireless Hotspot Miner
@@ -236,7 +281,10 @@ variant_definitions = {
         'BUTTON': 21,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Helium Hotspot
@@ -249,7 +297,10 @@ variant_definitions = {
         'BUTTON': 21,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # SenseCAP M1 Hotspot
@@ -262,7 +313,10 @@ variant_definitions = {
         'BUTTON': 21,
         'ECCOB': True,
         'TYPE': 'Full',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # DIY Pi Supply Hotspot HAT
@@ -275,7 +329,10 @@ variant_definitions = {
         'BUTTON': 21,
         'ECCOB': False,
         'TYPE': 'Light',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         },
 
     # Nebra Indoor Hotspot
@@ -288,6 +345,9 @@ variant_definitions = {
         'BUTTON': 21,
         'ECCOB': False,
         'TYPE': 'Light',
-        'CELLULAR': False
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'ICC_IDS': []
         }
 }

--- a/hm_pyhelper/tests/test_hardware_definitions.py
+++ b/hm_pyhelper/tests/test_hardware_definitions.py
@@ -18,7 +18,8 @@ class TestHardwareDefinitions(TestCase):
             'CELLULAR',
             'FCC_IDS',
             'CONTAINS_FCC_IDS',
-            'IC_IDS'
+            'IC_IDS',
+            'CONTAINS_IC_IDS'
         }
 
         for variant_name, variant_dict in variant_definitions.items():

--- a/hm_pyhelper/tests/test_hardware_definitions.py
+++ b/hm_pyhelper/tests/test_hardware_definitions.py
@@ -18,7 +18,7 @@ class TestHardwareDefinitions(TestCase):
             'CELLULAR',
             'FCC_IDS',
             'CONTAINS_FCC_IDS',
-            'ICC_IDS'
+            'IC_IDS'
         }
 
         for variant_name, variant_dict in variant_definitions.items():

--- a/hm_pyhelper/tests/test_hardware_definitions.py
+++ b/hm_pyhelper/tests/test_hardware_definitions.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+from hm_pyhelper.hardware_definitions import variant_definitions
+
+
+class TestHardwareDefinitions(TestCase):
+    def test_variant_definitions(self):
+        # Not currently expecting APPNAME, GPIO_PIN_LED, or PIO_PIN_BUTTON
+        expected_fields = {
+            'FRIENDLY',
+            'SPIBUS',
+            'RESET',
+            'MAC',
+            'STATUS',
+            'BUTTON',
+            'ECCOB',
+            'TYPE',
+            'CELLULAR',
+            'FCC_IDS',
+            'CONTAINS_FCC_IDS',
+            'ICC_IDS'
+        }
+
+        for variant_name, variant_dict in variant_definitions.items():
+            variant_keys = variant_dict.keys()
+            missing_keys = expected_fields.difference(variant_keys)
+            self.assertSetEqual(missing_keys, set())


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/Hotspot-Production-Tool/issues/12
- Summary: Support different FCC and ICC IDs on different devices.

**How**
- Added FCC and ICC ids to variant_defintions.
- Only set values for variants that are currently explicitly
  handled in HPT: https://github.com/NebraLtd/Hotspot-Production-Tool/blob/d948acc4245cbe66777cae26660789b249cbb349/app/main.py#L90
- For future proofing, made FCC_IDS an array even though we currently only seem to have one
value per device type.

**References**
- Related to: https://github.com/NebraLtd/Hotspot-Production-Tool/issues/34
- Related to: https://github.com/NebraLtd/Hotspot-Production-Tool/issues/11
- Related to: https://github.com/NebraLtd/Hotspot-Production-Tool/issues/10

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names