### PR TITLE
Better logic for DiagnosticsReport.passed method

### DIFF
--- a/hm_pyhelper/diagnostics/diagnostics_report.py
+++ b/hm_pyhelper/diagnostics/diagnostics_report.py
@@ -60,7 +60,6 @@ class DiagnosticsReport(dict):
         errors = self.get_errors()
 
         if errors:
-            self.set_passed(False)
             manufacturing_errors = \
                 self.KEYS_TO_CHECK_IN_MANUFACTUING.intersection(errors)
 

--- a/hm_pyhelper/diagnostics/diagnostics_report.py
+++ b/hm_pyhelper/diagnostics/diagnostics_report.py
@@ -33,10 +33,33 @@ class DiagnosticsReport(dict):
 
         if DIAGNOSTICS_ERRORS_KEY not in self:
             self.__setitem__(DIAGNOSTICS_ERRORS_KEY, [])
+
         self.diagnostics = diagnostics
 
+        # Needed for more verbose messages at HPT end. This attribute gets
+        # queried to display exactly which keys failed causing the diagnostics
+        # to fail.
+        self.manufacturing_errors = []
+
     def passed(self):
-        return self[DIAGNOSTICS_PASSED_KEY]
+        # Check only a subset of keys that are required for manufacturing
+        # tests. If these don't have errors then we can conclude that device
+        # is good from manufacturing point-of-view.
+        keys_to_check = {
+            'ECC', 'OK', 'E0', 'W0', 'PK', 'BT', 'VA', 'FR', 'serial_number'
+        }
+
+        errors = self.get_errors()
+        if errors:
+            self.set_passed(False)
+            self.manufacturing_errors = keys_to_check.intersection(errors)
+            if len(self.manufacturing_errors) > 0:
+                return False
+
+        else:
+            self.set_passed(True)
+
+        return True
 
     def set_passed(self, passed):
         self.__setitem__(DIAGNOSTICS_PASSED_KEY, passed)

--- a/hm_pyhelper/diagnostics/diagnostics_report.py
+++ b/hm_pyhelper/diagnostics/diagnostics_report.py
@@ -12,7 +12,8 @@ DIAGNOSTICS_ERRORS_KEY = 'errors'
 class DiagnosticsReport(dict):
 
     KEYS_TO_CHECK_IN_MANUFACTUING = {
-        'ECC', 'OK', 'E0', 'W0', 'PK', 'BT', 'VA', 'FR', 'serial_number'
+        'ECC', 'onboarding_key', 'eth_mac_address', 'wifi_mac_address',
+        'public_key', 'bluetooth', 'VARIANT', 'FREQ', 'serial_number'
     }
 
     def __init__(self, diagnostics=[], **kwargs):

--- a/hm_pyhelper/tests/test_diagnostic_report.py
+++ b/hm_pyhelper/tests/test_diagnostic_report.py
@@ -66,7 +66,7 @@ class TestDiagnostic(unittest.TestCase):
 
     def test_passed_success(self):
         report = DiagnosticsReport()
-        report['PF'] = True
+        report[DIAGNOSTICS_PASSED_KEY] = True
 
         self.assertTrue(report.passed())
 
@@ -103,7 +103,7 @@ class TestDiagnostic(unittest.TestCase):
             response['errors'] = [key]
             report = DiagnosticsReport.from_json_dict(response)
             self.assertFalse(report.passed())
-            assert report.manufacturing_errors == {key}
+            assert report.has_manufacturing_errors() == {key}
 
         response['errors'] = keys_to_test
         report = DiagnosticsReport.from_json_dict(response)
@@ -137,4 +137,4 @@ class TestDiagnostic(unittest.TestCase):
         }
 
         report = DiagnosticsReport.from_json_dict(response)
-        self.assertTrue(report.passed())
+        assert len(report.has_manufacturing_errors()) == 0

--- a/hm_pyhelper/tests/test_diagnostic_report.py
+++ b/hm_pyhelper/tests/test_diagnostic_report.py
@@ -72,7 +72,8 @@ class TestDiagnostic(unittest.TestCase):
 
     def test_passed_false_on_errors(self):
         keys_to_test = (
-            'ECC', 'BT', 'OK', 'E0', 'W0', 'PK', 'VA', 'FR', 'serial_number'
+            'ECC', 'onboarding_key', 'eth_mac_address', 'wifi_mac_address',
+            'public_key', 'bluetooth', 'VARIANT', 'FREQ', 'serial_number'
         )
 
         response = {
@@ -81,6 +82,7 @@ class TestDiagnostic(unittest.TestCase):
             'serial_number': '0000000021aabbcc',
             'ECC': 'gateway_mfr test finished with error',
             'E0': 'F0:4C:D5:58:E0:E1',
+            'eth_mac_address': 'F0:4C:D5:58:E0:E1',
             'FR': '915',
             'FREQ': '915',
             'FW': '2021.11.22.0-1',
@@ -88,6 +90,7 @@ class TestDiagnostic(unittest.TestCase):
             'VA': 'NEBHNT-OUT1',
             'VARIANT': 'NEBHNT-OUT1',
             'BT': True,
+            'bluetooth': True,
             'LTE': False,
             'LOR': False,
             'lora': False,
@@ -122,6 +125,7 @@ class TestDiagnostic(unittest.TestCase):
             'serial_number': '0000000021aabbcc',
             'ECC': True,
             'E0': 'F0:4C:D5:58:E0:E1',
+            'eth_mac_address': 'F0:4C:D5:58:E0:E1',
             'FR': '915',
             'FREQ': '915',
             'FW': '2021.11.22.0-1',
@@ -129,6 +133,7 @@ class TestDiagnostic(unittest.TestCase):
             'VA': 'NEBHNT-OUT1',
             'VARIANT': 'NEBHNT-OUT1',
             'BT': True,
+            'bluetooth': True,
             'LTE': False,
             'LOR': False,
             'lora': False,

--- a/hm_pyhelper/tests/test_diagnostic_report.py
+++ b/hm_pyhelper/tests/test_diagnostic_report.py
@@ -63,3 +63,78 @@ class TestDiagnostic(unittest.TestCase):
         self.assertDictEqual(diagnostics_report.get_report_subset(["VA"]), {
             'VA': 'NEBHNT-IN1'
         })
+
+    def test_passed_success(self):
+        report = DiagnosticsReport()
+        report['PF'] = True
+
+        self.assertTrue(report.passed())
+
+    def test_passed_false_on_errors(self):
+        keys_to_test = (
+            'ECC', 'BT', 'OK', 'E0', 'W0', 'PK', 'VA', 'FR', 'serial_number'
+        )
+
+        response = {
+            'diagnostics_passed': False,
+            'errors': ['ECC', 'BN', 'OK', 'PK', 'PF'],
+            'serial_number': '0000000021aabbcc',
+            'ECC': 'gateway_mfr test finished with error',
+            'E0': 'F0:4C:D5:58:E0:E1',
+            'FR': '915',
+            'FREQ': '915',
+            'FW': '2021.11.22.0-1',
+            'FIRMWARE_VERSION': '2021.11.22.0-1',
+            'VA': 'NEBHNT-OUT1',
+            'VARIANT': 'NEBHNT-OUT1',
+            'BT': True,
+            'LTE': False,
+            'LOR': False,
+            'lora': False,
+            'OK': 'gateway_mfr exited with a non-zero status',
+            'onboarding_key': 'gateway_mfr exited with a non-zero status',
+            'PK': 'gateway_mfr exited with a non-zero status',
+            'public_key': 'gateway_mfr exited with a non-zero status',
+            'PF': False,
+            'legacy_pass_fail': False
+        }
+
+        for key in keys_to_test:
+            response['errors'] = [key]
+            report = DiagnosticsReport.from_json_dict(response)
+            self.assertFalse(report.passed())
+            assert report.manufacturing_errors == {key}
+
+        response['errors'] = keys_to_test
+        report = DiagnosticsReport.from_json_dict(response)
+        self.assertFalse(report.passed())
+
+    def test_passed_on_non_manufacturing_errors(self):
+        """
+        Test that we're only considering a subset of keys
+        ['ECC', 'BT', 'OK', 'E0', 'W0', 'PK'] to determine if manufacturing
+        is good. Other keys may have errors but that should not cause miner
+        to fail manufacturing.
+        """
+        response = {
+            'diagnostics_passed': False,
+            'errors': ['BN', 'PF'],
+            'serial_number': '0000000021aabbcc',
+            'ECC': True,
+            'E0': 'F0:4C:D5:58:E0:E1',
+            'FR': '915',
+            'FREQ': '915',
+            'FW': '2021.11.22.0-1',
+            'FIRMWARE_VERSION': '2021.11.22.0-1',
+            'VA': 'NEBHNT-OUT1',
+            'VARIANT': 'NEBHNT-OUT1',
+            'BT': True,
+            'LTE': False,
+            'LOR': False,
+            'lora': False,
+            'PF': False,
+            'legacy_pass_fail': False
+        }
+
+        report = DiagnosticsReport.from_json_dict(response)
+        self.assertTrue(report.passed())

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.12.2',
+    version='0.12.3',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.12.3',
+    version='0.12.4',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
Related to https://github.com/NebraLtd/Hotspot-Production-Tool/issues/55
Moved logic of did_miner_pass_diagnostics from Miner class in HPT to
DiagnosticsReport.passed method. Added relevant test cases.

**Issue**
Avoid code duplication and use better logic for determining if diagnostics have passed.

- Link:
- Summary:
Previously only the passed key was being checked to see if diagnostics report had passed. Now this checks more keys to make sure all keys required for passing the report at manufacturing have valid values.

**How**
Implementation logic from https://github.com/NebraLtd/Hotspot-Production-Tool/blob/kashifpk/refactoring/app/src/hpt/miner.py#L165 was taken and moved to `DiagnosticReport.passed` method with appropriate adjustments.

**Checklist**

- [X] Tests added
- [X] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [X] Thought about variable and method names
