### PR TITLE
Diagnostics report friendly keys support

### DIFF
--- a/hm_pyhelper/diagnostics/diagnostics_report.py
+++ b/hm_pyhelper/diagnostics/diagnostics_report.py
@@ -91,6 +91,7 @@ class DiagnosticsReport(dict):
 
         # Add the failing key to list of errors
         self.append_error(diagnostic.key)
+        self.append_error(diagnostic.friendly_key)
 
         # Provide additional details, like error message
         record_failure_as = msg_or_exception

--- a/hm_pyhelper/tests/test_diagnostic_report.py
+++ b/hm_pyhelper/tests/test_diagnostic_report.py
@@ -24,10 +24,9 @@ class TestDiagnostic(unittest.TestCase):
         diagnostic = Diagnostic('key', 'friendly_name')
         diagnostics_report = DiagnosticsReport()
         diagnostics_report.record_failure('foo', diagnostic)
-
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['key'],
+            DIAGNOSTICS_ERRORS_KEY: ['key', 'friendly_name'],
             'key': 'foo',
             'friendly_name': 'foo'
         })
@@ -45,14 +44,15 @@ class TestDiagnostic(unittest.TestCase):
         })
 
     def test_get_error_messages(self):
-        diagnostic1 = Diagnostic('key1', 'friendly_name')
-        diagnostic2 = Diagnostic('key2', 'friendly_name')
+        diagnostic1 = Diagnostic('key1', 'friendly_name1')
+        diagnostic2 = Diagnostic('key2', 'friendly_name2')
         diagnostics_report = DiagnosticsReport()
         diagnostics_report.record_failure('Error1', diagnostic1)
         diagnostics_report.record_failure('Error2', diagnostic2)
 
         actual_msgs = diagnostics_report.get_error_messages()
-        expected_msgs = "key1 Error: Error1\nkey2 Error: Error2"
+        expected_msgs = "key1 Error: Error1\nfriendly_name1 Error: Error1" + \
+            "\nkey2 Error: Error2\nfriendly_name2 Error: Error2"
         self.assertEqual(actual_msgs, expected_msgs)
 
     def test_get_report_subset(self):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.12.4',
+    version='0.12.5',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Issue**
Proper method of setting errors for diagnostics report (used in hm-diag) was using old style keys.


**How**
Added support in `DiagnosticsReport.record_failure` method to add both provided key and friendly_key to errors.

**Checklist**

- [X] Tests updated
- [X] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [X] Thought about variable and method names