### PR TITLE
feat(diagnostics): get_missing_keys

### DIFF
--- a/hm_pyhelper/diagnostics/diagnostics_report.py
+++ b/hm_pyhelper/diagnostics/diagnostics_report.py
@@ -53,6 +53,18 @@ class DiagnosticsReport(dict):
     def get_errors(self):
         return self[DIAGNOSTICS_ERRORS_KEY]
 
+    def get_missing_keys(self, required_keys: set) -> set:
+        """
+        Get required_keys that are missing from the DiagnosticsReport.
+
+        Args:
+            required_keys (set): Key names that should be present.
+
+        Returns:
+            set: Of keys that are missing
+        """
+        return required_keys.difference(self.keys())
+
     def has_manufacturing_errors(self) -> list:
         # Check only a subset of keys that are required for manufacturing
         # tests. If these don't have errors then we can conclude that device

--- a/hm_pyhelper/tests/test_diagnostic_report.py
+++ b/hm_pyhelper/tests/test_diagnostic_report.py
@@ -143,3 +143,20 @@ class TestDiagnostic(unittest.TestCase):
 
         report = DiagnosticsReport.from_json_dict(response)
         assert len(report.has_manufacturing_errors()) == 0
+
+    def test_assert_diagnostics_present(self):
+        diagnostics_report = DiagnosticsReport.from_json_dict({
+            'foo': 'bar'
+        })
+
+        missing_keys = diagnostics_report.get_missing_keys({'foo'})
+
+        self.assertEqual(missing_keys, set())
+
+    def test_assert_diagnostics_not_present(self):
+        diagnostics_report = DiagnosticsReport.from_json_dict({
+            'foo': 'bar'
+        })
+
+        missing_keys = diagnostics_report.get_missing_keys({'missing_key'})
+        self.assertEqual(missing_keys, {'missing_key'})

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.12.6',
+    version='0.12.7',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/Hotspot-Production-Tool/pull/117
- Summary: Add helper method to be used by l[abel printing logic](https://github.com/NebraLtd/Hotspot-Production-Tool/pull/117#discussion_r782612628) in HPT to validate before printing.

**How**
Added method to DiagnosticsReport to detect which keys are present.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names