### PR TITLE
Remove library jsonrpcclient from hm_pyhelper 

### DIFF
--- a/hm_pyhelper/miner_json_rpc/client.py
+++ b/hm_pyhelper/miner_json_rpc/client.py
@@ -28,7 +28,7 @@ class Client(object):
             )
 
         if not response.ok:
-            raise Exception("Error happened")
+            response.raise_for_status()
 
         return response.json().get('result')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-jsonrpcclient==4.0.2
 requests==2.26.0
 retry==0.9.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.12.8',
+    version='0.13.0',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**How**
Remove jsonrpcclient library from source code. And start using 'requests' library for all requests.

**Checklist**

- [x] Tests fixed
- [x] Cleaned up commit history (rebase!)
