### PR TITLE
Fix get peer book requests

### DIFF
--- a/hm_pyhelper/miner_json_rpc/client.py
+++ b/hm_pyhelper/miner_json_rpc/client.py
@@ -9,12 +9,14 @@ class Client(object):
     def __init__(self, url='http://helium-miner:4467'):
         self.url = url
 
-    def __fetch_data(self, method):
+    def __fetch_data(self, method, **kwargs):
         req_body = {
             "jsonrpc": "2.0",
             "id": 1,
             "method": method,
         }
+        if kwargs:
+            req_body["params"] = kwargs
         try:
             response = requests.post(self.url, json=req_body)
         except requests.exceptions.ConnectionError:
@@ -51,7 +53,7 @@ class Client(object):
         return self.__fetch_data('peer_addr')
 
     def get_peer_book(self):
-        return self.__fetch_data('peer_book')
+        return self.__fetch_data('peer_book', addr='self')
 
     def get_firmware_version(self):
         summary = self.get_summary()

--- a/hm_pyhelper/tests/test_miner_json_rpc.py
+++ b/hm_pyhelper/tests/test_miner_json_rpc.py
@@ -160,8 +160,10 @@ class TestMinerJSONRPC(unittest.TestCase):
 
         client = MinerClient()
         result = client.get_peer_book()
+        payload = return_payload_with_method('peer_book')
+        payload["params"] = {'addr': 'self'}
         mock_json_rpc_client.assert_called_with(
-            BASE_URL, json=return_payload_with_method('peer_book')
+            BASE_URL, json=payload
         )
         self.assertEqual(result, [])
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.0',
+    version='0.13.1',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**How**
When trying to get information using the request "peer_book". It always returns None.

It is necessary to add the ability to added the payload for some requests for correct operation.
