### PR TITLE
Increased max line length to 100 for flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100


### PR DESCRIPTION
Since this is just a config change no need to bump version for this one as it will only effect devs.