### PR TITLE
Fixed: RAK button GPIO mapping has been corrected.

### DIFF
--- a/hm_pyhelper/hardware_definitions.py
+++ b/hm_pyhelper/hardware_definitions.py
@@ -311,7 +311,7 @@ variant_definitions = {
         'RESET': 25,
         'MAC': 'wlan0',
         'STATUS': 20,
-        'BUTTON': 21,
+        'BUTTON': 7,
         'ECCOB': True,
         'TYPE': 'Full',
         'CELLULAR': False,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.11',
+    version='0.13.12',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Issue**
(NebraLtd/hm-pyhelper#125)

- Summary:
The RAK button has been incorrectly mapped to GPIO21 and we needed to move it to GPIO7 for the actual hardware (RAK2287 Pi HAT). It will also require a change in the config.txt but this will be done in another repo later.

**How**
- The GPIO has been set to 7 for COMP-RAKHM

**Checklist**

- [ ] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names