### PR TITLE
Bugfix for get payload from clearsigned message

### DIFF
--- a/hm_pyhelper/util/pgp.py
+++ b/hm_pyhelper/util/pgp.py
@@ -20,16 +20,13 @@ def get_payload_from_clearsigned_message(message: str) -> str:
 
     start_idx = 3  # Payload starts from 3rd line in clearsigned messages
     end_idx = None
-    prev_line = ""
 
     for idx, line in enumerate(lines[3:]):
-        if line.strip() == '-----BEGIN PGP SIGNATURE-----' and prev_line.strip() == "":
+        if line.strip() == '-----BEGIN PGP SIGNATURE-----':
             end_idx = idx + start_idx
             break
-
-        prev_line = line
 
     if end_idx is None:
         raise RuntimeError("Invalid message format, no --BEGIN PGP SIGNATURE-- section")
 
-    return "\n".join(lines[start_idx: end_idx-1])
+    return "\n".join(lines[start_idx: end_idx])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.12',
+    version='0.13.14',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.11',
+    version='0.13.12',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
`util.get_payload_from_clearsigned_message` was not extracting payload correctly if the original payload file used for signing did not end with a new line. This fixes it.