### PR TITLE
fix: is_rockpi and is_raspberry_pi should not break outside Balena #69

### DIFF
--- a/hm_pyhelper/hardware_definitions.py
+++ b/hm_pyhelper/hardware_definitions.py
@@ -1,31 +1,14 @@
-import os
+import hm_pyhelper.sbc as sbc
 from hm_pyhelper.exceptions import UnknownVariantException, \
-                                   UnknownVariantAttributeException
+    UnknownVariantAttributeException
 
 
-def is_rockpi():
-    return 'rockpi-4b-rk3399' in os.getenv('BALENA_DEVICE_TYPE')
+def is_rockpi() -> bool:
+    return sbc.is_sbc_type(sbc.DeviceVendorID.ROCK_PI)
 
 
-def is_raspberry_pi():
-    """
-    Pulled from
-    https://www.balena.io/docs/reference/base-images/devicetypes/
-    """
-    device_type = os.getenv('BALENA_DEVICE_TYPE')
-    device_type_match = [
-        'raspberry-pi2',
-        'raspberrypi3',
-        'raspberrypi3-64',
-        'raspberrypi4-64',
-        'nebra-hnt',
-        'raspberrypicm4-ioboard'
-    ]
-
-    for device in device_type_match:
-        if device in device_type:
-            return True
-    return False
+def is_raspberry_pi() -> bool:
+    return sbc.is_sbc_type(sbc.DeviceVendorID.RASPBERRY_PI)
 
 
 variant_definitions = {

--- a/hm_pyhelper/sbc.py
+++ b/hm_pyhelper/sbc.py
@@ -1,0 +1,78 @@
+"""
+This module provides a set of functions to extract information about
+the Single Board Computer in use.
+It considers Balena environment variables as primary source of truth.
+It also uses the device tree to extract information about the SBC.
+"""
+
+import os
+from enum import Enum, auto
+from collections import namedtuple
+
+SBCInfo = namedtuple('SBCInfo', ['vendor_id', 'vendor_name', 'model_name'])
+
+
+class DeviceVendorID(Enum):
+    """
+    Enum for device vendors.
+    """
+    INVALID = auto()
+    ROCK_PI = auto()
+    RASPBERRY_PI = auto()
+
+
+BALENA_ENV_RASPBERRY_PI_MODELS = [
+    """
+    Pulled from
+    https://www.balena.io/docs/reference/base-images/devicetypes/
+    """
+    'raspberry-pi2',
+    'raspberrypi3',
+    'raspberrypi3-64',
+    'raspberrypi4-64',
+    'nebra-hnt',
+    'raspberrypicm4-ioboard'
+]
+
+BALENA_ENV_ROCKPI_MODELS = ['rockpi-4b-rk3399']
+
+BALENA_MODELS = {
+    DeviceVendorID.ROCK_PI: BALENA_ENV_ROCKPI_MODELS,
+    DeviceVendorID.RASPBERRY_PI: BALENA_ENV_RASPBERRY_PI_MODELS
+}
+
+
+def device_model():
+    with open('/proc/device-tree/model', 'r') as f:
+        return f.readline().strip()
+
+
+def sbc_info() -> SBCInfo:
+    '''
+    return SBCInfo formed by reading '/proc/device-tree/model'
+    '''
+    sbc_info = SBCInfo(vendor_id=DeviceVendorID.INVALID, vendor_name='', model_name='')
+    dev_model = device_model()
+    if dev_model.lower().find('raspberry') >= 0:
+        sbc_info = SBCInfo(vendor_id=DeviceVendorID.RASPBERRY_PI,
+                           vendor_name='Raspberry Pi',
+                           model_name=dev_model)
+    elif dev_model.lower().find('rock') >= 0:
+        sbc_info = SBCInfo(vendor_id=DeviceVendorID.ROCK_PI,
+                           vendor_name='Radxa Rock Pi',
+                           model_name=dev_model)
+    return sbc_info
+
+
+def is_sbc_type(device_id: DeviceVendorID) -> bool:
+    '''
+    Return true if the sbc matches the type supplied.
+    '''
+    device_type = os.getenv('BALENA_DEVICE_TYPE')
+
+    # use device tree supplied model name if evn not set
+    if not device_type:
+        return sbc_info().vendor_id == device_id
+
+    # honor env override
+    return device_type in BALENA_MODELS.get(device_id, [])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.15',
+    version='0.13.16',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
* read model information from /proc/device-tree/model
in the absense of balena env variable

**fix: is_rockpi and is_raspberry_pi should not break outside Balena**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/69
- Summary:

**How**
We read /proc/device-tree/model in the absence of BALENA_DEVICE_TYPE to determine device type.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names