### PR TITLE
 add support for balena device types pi zero #153 

### DIFF
--- a/hm_pyhelper/hardware_definitions.py
+++ b/hm_pyhelper/hardware_definitions.py
@@ -94,7 +94,7 @@ variant_definitions = {
     'NEBHNT-LGT-ZS': {
         'FRIENDLY': 'Nebra Pi 0 Light Hotspot SE',
         'APPNAME': 'Pi 0 Light',
-        'SPIBUS': 'spidev1.2',
+        'SPIBUS': 'spidev0.0',
         'KEY_STORAGE_BUS': '/dev/i2c-1',
         'RESET': 22,
         'MAC': 'wlan0',
@@ -113,7 +113,7 @@ variant_definitions = {
     'NEBHNT-LGT-ZX': {
         'FRIENDLY': 'Nebra Pi 0 Light Hotspot XE',
         'APPNAME': 'Pi 0 Light',
-        'SPIBUS': 'spidev1.2',
+        'SPIBUS': 'spidev0.0',
         'KEY_STORAGE_BUS': '/dev/i2c-1',
         'RESET': 22,
         'MAC': 'wlan0',

--- a/hm_pyhelper/sbc.py
+++ b/hm_pyhelper/sbc.py
@@ -21,17 +21,17 @@ class DeviceVendorID(Enum):
     RASPBERRY_PI = auto()
 
 
+# Pulled from
+# https://www.balena.io/docs/reference/base-images/devicetypes/
 BALENA_ENV_RASPBERRY_PI_MODELS = [
-    """
-    Pulled from
-    https://www.balena.io/docs/reference/base-images/devicetypes/
-    """
+    'raspberry-pi',
     'raspberry-pi2',
     'raspberrypi3',
     'raspberrypi3-64',
     'raspberrypi4-64',
     'nebra-hnt',
-    'raspberrypicm4-ioboard'
+    'raspberrypicm4-ioboard',
+    'raspberrypi0-2w-64'
 ]
 
 BALENA_ENV_ROCKPI_MODELS = ['rockpi-4b-rk3399']

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.19',
+    version='0.13.20',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**#153**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/153
- Summary: support sbc types pi zero 1 and 2

**How**
added balena device types names
fixed spidev number for pi zero

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names