### PR TITLE
Revert "fix: pi zero support, spi dev number #153"

### DIFF
--- a/hm_pyhelper/hardware_definitions.py
+++ b/hm_pyhelper/hardware_definitions.py
@@ -94,7 +94,7 @@ variant_definitions = {
     'NEBHNT-LGT-ZS': {
         'FRIENDLY': 'Nebra Pi 0 Light Hotspot SE',
         'APPNAME': 'Pi 0 Light',
-        'SPIBUS': 'spidev0.0',
+        'SPIBUS': 'spidev1.2',
         'KEY_STORAGE_BUS': '/dev/i2c-1',
         'RESET': 22,
         'MAC': 'wlan0',
@@ -113,7 +113,7 @@ variant_definitions = {
     'NEBHNT-LGT-ZX': {
         'FRIENDLY': 'Nebra Pi 0 Light Hotspot XE',
         'APPNAME': 'Pi 0 Light',
-        'SPIBUS': 'spidev0.0',
+        'SPIBUS': 'spidev1.2',
         'KEY_STORAGE_BUS': '/dev/i2c-1',
         'RESET': 22,
         'MAC': 'wlan0',


### PR DESCRIPTION
This reverts commit 40a07c9301f665648cd09d2ab9154a4e4a25ff5c.

**[Issue](https://github.com/NebraLtd/hm-pyhelper/issues/153)**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/153
- Summary: had merged wrong spi dev to master. reverting.

**How**
Mistakenly I thought new carrier board for light gateway and old hat are same. Modified spidev to make old hat work with pi zero but that is not the case. New carrier board uses spi1 for concentrator.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names