### PR TITLE
Tolerate gateway_mfr errors

### DIFF
--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -50,29 +50,29 @@ def run_gateway_mfr(args):
             'gateway_mfr response stderr: %s' % run_gateway_mfr_result.stderr)
     except subprocess.CalledProcessError as e:
         err_str = "gateway_mfr exited with a non-zero status"
-        LOGGER.exception(err_str)
+        LOGGER.warning(err_str)
         raise ECCMalfunctionException(err_str).with_traceback(e.__traceback__)
     except (FileNotFoundError, NotADirectoryError) as e:
         err_str = "file/directory for gateway_mfr was not found"
-        LOGGER.exception(err_str)
+        LOGGER.warning(err_str)
         raise GatewayMFRFileNotFoundException(err_str) \
             .with_traceback(e.__traceback__)
     except ResourceBusyError as e:
         err_str = "resource busy error: %s"
-        LOGGER.exception(err_str % str(e))
+        LOGGER.warning(err_str % str(e))
         raise ResourceBusyError(e)\
             .with_traceback(e.__traceback__)
     except Exception as e:
         err_str = "Exception occured on running gateway_mfr %s" \
                   % str(e)
-        LOGGER.exception(e)
+        LOGGER.warning(e)
         raise ECCMalfunctionException(err_str).with_traceback(e.__traceback__)
 
     try:
         return json.loads(run_gateway_mfr_result.stdout)
     except json.JSONDecodeError as e:
         err_str = "Unable to parse JSON from gateway_mfr"
-        LOGGER.exception(err_str)
+        LOGGER.warning(err_str)
         raise ECCMalfunctionException(err_str).with_traceback(e.__traceback__)
 
 


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-diag/issues/352
- Summary:
Should not generate sentry errors when `gateway_mfr` is exited with a non-zero status.

**How**
The status of `gateway_mfr` is still logged but it shouldn't be logged in ERROR level so that no sentry issue to be made.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names