### PR TITLE
Add packaging dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests==2.26.0
 retry==0.9.2
 base58==2.1.1
 protobuf==3.19.3
+packaging>=21.3

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.26',
+    version='0.13.27',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",
@@ -15,6 +15,7 @@ setup(
         'retry==0.9.2',
         'base58==2.1.1',
         'protobuf==3.19.3'
+        'packaging>=21.3'
     ],
     project_urls={
         "Bug Tracker": "https://github.com/NebraLtd/hm-pyhelper/issues",


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/164
- Summary:
[packaging](https://pypi.org/project/packaging/) is used for gateway_mfr version checking, so `packaging` dependency needs to be added.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names