### PR TITLE
Fix parsing subprocess output

### DIFF
--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -90,7 +90,7 @@ def get_gateway_mfr_version() -> Version:
 
     # Parse gateway_mfr version
     try:
-        version_str = run_gateway_mfr_result.stdout.rpartition(' ')[-1]
+        version_str = run_gateway_mfr_result.stdout.decode().rpartition(' ')[-1]
         gateway_mfr_version = Version(version_str)
 
         return gateway_mfr_version

--- a/hm_pyhelper/tests/test_miner_param.py
+++ b/hm_pyhelper/tests/test_miner_param.py
@@ -118,7 +118,7 @@ class TestMinerParam(unittest.TestCase):
         mocked_subprocess_run.assert_called_once_with(
             [ANY, '--version'], capture_output=True, check=True)
 
-    @patch('subprocess.run', return_value=SubprocessResult(stdout='gateway_mfr 0.1.7'))
+    @patch('subprocess.run', return_value=SubprocessResult(stdout=b'gateway_mfr 0.1.7'))
     def test_get_gateway_mfr_version_v017(self, mocked_subprocess_run):
         version = get_gateway_mfr_version()
 
@@ -129,7 +129,7 @@ class TestMinerParam(unittest.TestCase):
         mocked_subprocess_run.assert_called_once_with(
             [ANY, '--version'], capture_output=True, check=True)
 
-    @patch('subprocess.run', return_value=SubprocessResult(stdout='gateway_mfr 0.2.1'))
+    @patch('subprocess.run', return_value=SubprocessResult(stdout=b'gateway_mfr 0.2.1'))
     def test_get_gateway_mfr_version_v021(self, mocked_subprocess_run):
         version = get_gateway_mfr_version()
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.28',
+    version='0.13.29',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/164
- Summary:
Subprocess output is byte array but not the string. It needs to be converted before handled as string.

**How**
`decode()` method should be called on the byte array in order to convert to string.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names