### PR TITLE
Pritam/light hotspot json rpc is back

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ and formatted the same way as the [smartphone app expects](https://docs.helium.c
 
 Usage:
 ```
+While using miner container, use json rpc client
+client = MinerClient()
+While using gateway-rs container, use grpc client
 client = GatewayClient()
 result = client.create_add_gateway_txn('owner_address', 'payer_address', 'gateway_address')
 ```

--- a/hm_pyhelper/miner_json_rpc/__init__.py
+++ b/hm_pyhelper/miner_json_rpc/__init__.py
@@ -1,0 +1,1 @@
+from hm_pyhelper.miner_json_rpc.client import Client as MinerClient  # noqa

--- a/hm_pyhelper/miner_json_rpc/client.py
+++ b/hm_pyhelper/miner_json_rpc/client.py
@@ -1,0 +1,169 @@
+import requests
+import base64
+import base58
+
+from hm_pyhelper.protos import blockchain_txn_pb2, \
+                               blockchain_txn_add_gateway_v1_pb2
+from hm_pyhelper.miner_json_rpc.exceptions import MinerConnectionError, \
+                                                  MinerMalformedURL, \
+                                                  MinerRegionUnset, \
+                                                  MinerMalformedAddGatewayTxn
+
+
+class Client(object):
+
+    def __init__(self, url='http://helium-miner:4467'):
+        self.url = url
+
+    def __fetch_data(self, method, **kwargs):
+        req_body = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+        }
+        if kwargs:
+            req_body["params"] = kwargs
+        try:
+            response = requests.post(self.url, json=req_body)
+        except requests.exceptions.ConnectionError:
+            raise MinerConnectionError(
+                "Unable to connect to miner %s" % self.url
+            )
+        except requests.exceptions.MissingSchema:
+            raise MinerMalformedURL(
+                "Miner JSONRPC URL '%s' is not a valid URL"
+                % self.url
+            )
+
+        if not response.ok:
+            response.raise_for_status()
+
+        return response.json().get('result')
+
+    def get_height(self):
+        return self.__fetch_data('info_height')
+
+    def get_region(self):
+        region = self.__fetch_data('info_region')
+        if not region.get('region'):
+            raise MinerRegionUnset(
+                "Miner at %s does not have an asserted region"
+                % self.url
+            )
+        return region
+
+    def get_summary(self):
+        return self.__fetch_data('info_summary')
+
+    def get_peer_addr(self):
+        return self.__fetch_data('peer_addr')
+
+    def get_peer_book(self):
+        return self.__fetch_data('peer_book', addr='self')
+
+    def get_firmware_version(self):
+        summary = self.get_summary()
+        return summary.get('firmware_version')
+
+    def create_add_gateway_txn(self, owner_address: str, payer_address: str,
+                               gateway_address: str = None) -> dict:
+        """
+        Invokes the txn_add_gateway RPC endpoint on the miner and returns
+        the same payload that the smartphone app traditionally expects.
+        https://docs.helium.com/mine-hnt/full-hotspots/become-a-maker/hotspot-integration-testing/#generate-an-add-hotspot-transaction
+
+        Alternatively, the same thing can be accomplished with dbus,
+        like in the below, but RPC is generally easier to use.
+        https://github.com/NebraLtd/hm-config/blob/900aeed353fb9729b49bca97d7da8a9abf0a2029/gatewayconfig/bluetooth/characteristics/add_gateway_characteristic.py#L71
+
+        Parameters:
+            - owner_address: The address of the account that owns the gateway.
+            - payer_address: The address of the account that will pay for the
+                             transaction. This will typically be the
+                             maker/Nebra's account.
+            - gateway_address: The address of the miner itself. This is
+                               an optional parameter because the miner
+                               will always return it in the payload during
+                               transaction generation. If the param is
+                               provided, it will only be used as extra
+                               validation.
+
+        Raises:
+            - MinerMalformedAddGatewayTxn if returned transaction does
+              not correspond to the supplied parameters.
+        """
+        # Invoke add_gateway_txn on miner
+        # https://github.com/helium/miner/blob/b9d2cd108cdcc864b641ccf4209f790b1461926d/src/jsonrpc/miner_jsonrpc_txn.erl#L31
+        rpc_response = self.__fetch_data('txn_add_gateway',
+                                         owner=owner_address,
+                                         payer=payer_address)
+        encoded_wrapped_txn = rpc_response['result']
+
+        # Base64 decode
+        # https://github.com/helium/miner/blob/b9d2cd108cdcc864b641ccf4209f790b1461926d/src/jsonrpc/miner_jsonrpc_txn.erl#L38
+        decoded_wrapped_txn = base64.b64decode(encoded_wrapped_txn)
+
+        # Deserialize wrapped protobuf
+        # https://github.com/helium/blockchain-core/blob/3cd6bca6c5595a1363a9bbd625ef254383a4141b/src/transactions/blockchain_txn.erl#L160
+        wrapped_txn = blockchain_txn_pb2.blockchain_txn()
+        wrapped_txn.ParseFromString(decoded_wrapped_txn)
+
+        # Unwrap to get blockchain_txn_add_gateway_v1
+        # https://github.com/helium/proto/blob/6dc60a9933628c3baf9d2f5386481f20a5d79bb8/src/blockchain_txn_add_gateway_v1.proto#L1
+        add_gateway_txn = wrapped_txn.add_gateway
+
+        txn_gateway_address = get_address_from_add_gateway_txn(
+            add_gateway_txn, 'gateway', gateway_address)
+
+        txn_owner_address = get_address_from_add_gateway_txn(
+            add_gateway_txn, 'owner', owner_address)
+
+        txn_payer_address = get_address_from_add_gateway_txn(
+            add_gateway_txn, 'payer', payer_address)
+
+        return {
+            'gateway_address': txn_gateway_address,
+            'owner_address': txn_owner_address,
+            'payer_address': txn_payer_address,
+            'fee': add_gateway_txn.fee,
+            'staking_fee': add_gateway_txn.staking_fee,
+            'txn': encoded_wrapped_txn
+        }
+
+
+def get_address_from_add_gateway_txn(add_gateway_txn:
+                                     blockchain_txn_add_gateway_v1_pb2,
+                                     address_type: str,
+                                     expected_address: str = None):
+    """
+    Deserializes specified field in the blockchain_txn_add_gateway_v1_pb2
+    protobuf to a base58 Helium address.
+
+    Pararms:
+        - add_gateway_txn: The blockchain_txn_add_gateway_v1_pb2 to
+                           inspect.
+        - address_type: 'owner', 'gateway', or 'payer'.
+        - expected_address (optional): Value we expect to be returned.
+
+    Raises:
+        MinerMalformedAddGatewayTxn if expected_address supplied and
+        does not match the return value.
+    """
+
+    # Addresses returned by the RPC response are missing a leading
+    # byte for the version. The version is currently always 0.
+    # https://github.com/helium/helium-js/blob/8d5cb76e156fb80de6fc80f239b43e3872c7b7d7/packages/crypto/src/Address.ts#L64
+    version_byte = b'\x00'
+
+    # Convert binary address to base58
+    address_bytes = version_byte + getattr(add_gateway_txn, address_type)
+    address = str(base58.b58encode_check(address_bytes), 'utf-8')
+
+    # Ensure resulting address matches expectation
+    is_expected_address_defined = expected_address is not None
+    if is_expected_address_defined and address != expected_address:
+        msg = f"Expected {address_type} address to be {expected_address}," + \
+              f"but is {address}"
+        raise MinerMalformedAddGatewayTxn(msg)
+
+    return address

--- a/hm_pyhelper/miner_json_rpc/exceptions.py
+++ b/hm_pyhelper/miner_json_rpc/exceptions.py
@@ -1,0 +1,26 @@
+class MinerJSONRPCException(Exception):
+    pass
+
+
+class MinerConnectionError(MinerJSONRPCException):
+    pass
+
+
+class MinerMalformedURL(MinerJSONRPCException):
+    pass
+
+
+class MinerRegionUnset(MinerJSONRPCException):
+    pass
+
+
+class MinerFailedFetchData(MinerJSONRPCException):
+    pass
+
+
+class MinerFailedToFetchEthernetAddress(MinerJSONRPCException):
+    pass
+
+
+class MinerMalformedAddGatewayTxn(MinerJSONRPCException):
+    pass

--- a/hm_pyhelper/tests/test_miner_json_rpc.py
+++ b/hm_pyhelper/tests/test_miner_json_rpc.py
@@ -1,0 +1,244 @@
+import unittest
+import mock
+import responses
+import requests
+from hm_pyhelper.miner_json_rpc import MinerClient
+from hm_pyhelper.miner_json_rpc.exceptions import MinerRegionUnset
+from hm_pyhelper.miner_json_rpc.exceptions import MinerMalformedURL
+from hm_pyhelper.miner_json_rpc.exceptions import MinerConnectionError
+
+BASE_URL = 'http://helium-miner:4467'
+
+
+@responses.activate
+def response_result(data, status):
+    url = "https://fake_url"
+    responses.add(responses.POST, url, json=data, status=status)
+    resp = requests.post(url)
+    print(resp.json())
+    return resp
+
+
+def return_payload_with_method(method):
+    return {'jsonrpc': '2.0', 'id': 1, 'method': method}
+
+
+class Result(object):
+    def __init__(self, result={'my': 'data'}):
+        self.result = result
+
+
+class Response(object):
+    def __init__(self, data=Result()):
+        self.data = data
+
+
+class TestMinerJSONRPC(unittest.TestCase):
+    def test_instantiation(self):
+        client = MinerClient()
+        self.assertIsInstance(client, MinerClient)
+        self.assertEqual(client.url, BASE_URL)
+
+    def test_malformed_url(self):
+        client = MinerClient(url='fakeurl')
+
+        exception_raised = False
+        exception_type = None
+        try:
+            client.get_height()
+        except Exception as exc:
+            exception_raised = True
+            exception_type = exc
+
+        self.assertTrue(exception_raised)
+        self.assertIsInstance(exception_type, MinerMalformedURL)
+
+    def test_connection_error(self):
+        client = MinerClient(url='http://notarealminer:9999')
+
+        exception_raised = False
+        exception_type = None
+        try:
+            client.get_height()
+        except Exception as exc:
+            exception_raised = True
+            exception_type = exc
+
+        self.assertTrue(exception_raised)
+        self.assertIsInstance(exception_type, MinerConnectionError)
+
+    @mock.patch('hm_pyhelper.miner_json_rpc.client.requests.post',
+                return_value=response_result(
+                    {"result": {'epoch': 25612, 'height': 993640}, "id": 1},
+                    200))
+    def test_get_height(self, mock_json_rpc_client):
+        client = MinerClient()
+        result = client.get_height()
+        mock_json_rpc_client.assert_called_with(
+            BASE_URL, json=return_payload_with_method('info_height'))
+
+        self.assertEqual(result, {'epoch': 25612, 'height': 993640})
+
+    @mock.patch('hm_pyhelper.miner_json_rpc.client.requests.post',
+                return_value=response_result(
+                    {"result": {'region': None}, "id": 1}, 200))
+    def test_get_region_not_asserted(self, mock_json_rpc_client):
+        client = MinerClient()
+        exception_raised = False
+        exception_type = None
+
+        try:
+            client.get_region()
+        except Exception as exc:
+            exception_raised = True
+            exception_type = exc
+
+        self.assertTrue(exception_raised)
+        self.assertIsInstance(exception_type, MinerRegionUnset)
+
+    @mock.patch('hm_pyhelper.miner_json_rpc.client.requests.post',
+                return_value=response_result(
+                    {"result": {'region': "EU868"}, "id": 1}, 200))
+    def test_get_region(self, mock_json_rpc_client):
+        client = MinerClient()
+        result = client.get_region()
+        mock_json_rpc_client.assert_called_with(
+            BASE_URL, json=return_payload_with_method('info_region')
+        )
+        self.assertEqual(result, {'region': 'EU868'})
+
+    summary = {
+        'block_age': 1136610,
+        'epoch': 25612,
+        'firmware_version': "0.1",
+        'gateway_details': 'undefined',
+        'height': 993640,
+        'mac_addresses': [
+            {'eth0': '0242AC110002'},
+            {'ip6tnl0': '00000000000000000000000000000000'},
+            {'tunl0': '00000000'},
+            {'lo': '000000000000'}
+        ],
+        'name': 'scruffy-chocolate-shell',
+        'peer_book_entry_count': 3,
+        'sync_height': 993640,
+        'uptime': 144,
+        'version': 10010005
+    }
+
+    result_json = {"result": summary, "id": 1}
+
+    @mock.patch('hm_pyhelper.miner_json_rpc.client.requests.post',
+                return_value=response_result(result_json, 200))
+    def test_get_summary(self, mock_json_rpc_client):
+        client = MinerClient()
+        result = client.get_summary()
+        mock_json_rpc_client.assert_called_with(
+            BASE_URL, json=return_payload_with_method('info_summary')
+        )
+        self.assertEqual(result, self.summary)
+
+    peer_addr = '/p2p/11jr2kMp1bZvSC6pd3XkNvs9Q43qCgEzxRwV6vpuqXanC5UcLEs'
+
+    @mock.patch('hm_pyhelper.miner_json_rpc.client.requests.post',
+                return_value=response_result(
+                    {"result": {'peer_addr': peer_addr}, "id": 1}, 200))
+    def test_get_peer_addr(self, mock_json_rpc_client):
+
+        client = MinerClient()
+        result = client.get_peer_addr()
+        mock_json_rpc_client.assert_called_with(
+            BASE_URL, json=return_payload_with_method('peer_addr')
+        )
+        self.assertEqual(result, {'peer_addr': self.peer_addr})
+
+    @mock.patch('hm_pyhelper.miner_json_rpc.client.requests.post',
+                return_value=response_result(
+                    {"result": [], "id": 1},
+                    200))
+    def test_get_peer_book(self, mock_json_rpc_client):
+
+        client = MinerClient()
+        result = client.get_peer_book()
+        payload = return_payload_with_method('peer_book')
+        payload["params"] = {'addr': 'self'}
+        mock_json_rpc_client.assert_called_with(
+            BASE_URL, json=payload
+        )
+        self.assertEqual(result, [])
+
+    firmware_version = '2021.10.18.0'
+    data_response = {
+        'block_age': 1136610,
+        'epoch': 25612,
+        'firmware_version': firmware_version,
+        'gateway_details': 'undefined',
+        'height': 993640,
+        'mac_addresses': [
+            {'eth0': '0242AC110002'},
+            {'ip6tnl0': '00000000000000000000000000000000'},
+            {'tunl0': '00000000'},
+            {'lo': '000000000000'}
+        ],
+        'name': 'scruffy-chocolate-shell',
+        'peer_book_entry_count': 3,
+        'sync_height': 993640,
+        'uptime': 144,
+        'version': 10010005
+    }
+
+    result_response = {"result": data_response, "id": 1}
+
+    @mock.patch('hm_pyhelper.miner_json_rpc.client.requests.post',
+                return_value=response_result(
+                    result_response, 200))
+    def test_get_firmware_version(self, mock_json_rpc_client):
+        client = MinerClient()
+        result = client.get_firmware_version()
+        mock_json_rpc_client.assert_called_with(
+            BASE_URL, json=return_payload_with_method('info_summary')
+        )
+        self.assertEqual(result, self.firmware_version)
+
+    add_gateway_response = {
+        "jsonrpc": "2.0",
+        "result": {
+            "result": "CroBCiEBwPbb63LQD8x/m/ZDLLyOLgtxypQIjh+xPPS+d8g/i24SIQB"
+                      "8XdzWqrIF201DNKHpXKFtsMtgvZeqBBc1wOk9sV2j4SJGMEQCIGE82g"
+                      "Hbn0z/AOyaDXsuQDptC/I15fHCF//QEgzoxodrAiBsoRUiw8zMVttkP"
+                      "hEOoMfM0smmdCZPKX6tVOgK0s/0KiohAVHXaw1kNly2VOt47MlzTfkC"
+                      "IUTOgW34Orw1LSJt+9mCOICS9AFA6PsD"
+        },
+        "id": "1"
+    }
+
+    @mock.patch('hm_pyhelper.miner_json_rpc.client.requests.post',
+                return_value=response_result(
+                    add_gateway_response, 200))
+    def test_create_add_gateway_txn(self, mock_json_rpc_client):
+        self.maxDiff = None
+        client = MinerClient()
+        actual_result = client.create_add_gateway_txn(
+            '14QjC3A5DEH2uFwhDxyBHdFir7YWGG23Fic1wGvkCr6qrWC7Q47',
+            '13Zni1he7KY9pUmkXMhEhTwfUpL9AcEV1m2UbbvFsrU9QPTMgE3')
+
+        expected_result = {
+            'gateway_address':
+            '11wmnCAfvFkdx3Az1hesTsSv9YeBUhs8JZKjCqcs2vmRwRazpBa',
+
+            'owner_address':
+            '14QjC3A5DEH2uFwhDxyBHdFir7YWGG23Fic1wGvkCr6qrWC7Q47',
+
+            'payer_address':
+            '13Zni1he7KY9pUmkXMhEhTwfUpL9AcEV1m2UbbvFsrU9QPTMgE3',
+
+            'fee': 65000,
+            'staking_fee': 4000000,
+            'txn': "CroBCiEBwPbb63LQD8x/m/ZDLLyOLgtxypQIjh+xPPS+d8g/i24SIQB8Xd"
+                   "zWqrIF201DNKHpXKFtsMtgvZeqBBc1wOk9sV2j4SJGMEQCIGE82gHbn0z/"
+                   "AOyaDXsuQDptC/I15fHCF//QEgzoxodrAiBsoRUiw8zMVttkPhEOoMfM0s"
+                   "mmdCZPKX6tVOgK0s/0KiohAVHXaw1kNly2VOt47MlzTfkCIUTOgW34Orw1"
+                   "LSJt+9mCOICS9AFA6PsD"
+        }
+
+        self.assertDictEqual(actual_result, expected_result)


### PR DESCRIPTION
**[Issue](https://github.com/NebraLtd/hm-pyhelper/issues/163)**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/163
- Summary: make hm-pyhelper light-hotspot branch compatible with json rpc.

**How**
Brought back json rpc client.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names