### PR TITLE
ECC key provisioning retry logic

### DIFF
--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -130,7 +130,7 @@ def provision_key():
         if retries >= max_retries:
             break
 
-        sleep(randint(1, 5))
+        sleep(randint(1, 5))  # NOSONAR
         LOGGER.info("[ECC Provisioning] Retrying ...")
 
     return provisioning_successful

--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -1,7 +1,11 @@
 import os
 import subprocess
 import json
+from time import sleep
+from random import randint
+
 from retry import retry
+
 from hm_pyhelper.lock_singleton import ResourceBusyError, lock_ecc
 from hm_pyhelper.logger import get_logger
 from hm_pyhelper.exceptions import MalformedRegionException, \
@@ -105,14 +109,31 @@ def provision_key():
     if did_gateway_mfr_test_result_include_miner_key_pass(test_results):
         return True
 
-    try:
-        gateway_mfr_result = run_gateway_mfr(["provision"])
-        LOGGER.info("[ECC Provisioning] %s", gateway_mfr_result)
+    provisioning_successful = False
+    retries = 0
+    max_retries = 5
 
-    except subprocess.CalledProcessError:
-        LOGGER.error("[ECC Provisioning] Exited with a non-zero status")
-        return False
-    return True
+    while not provisioning_successful:
+        try:
+            gateway_mfr_result = run_gateway_mfr(["provision"])
+            LOGGER.info("[ECC Provisioning] %s", gateway_mfr_result)
+            provisioning_successful = True
+            break
+
+        except subprocess.CalledProcessError:
+            LOGGER.error("[ECC Provisioning] Exited with a non-zero status")
+
+        except Exception as exp:
+            LOGGER.error("[ECC Provisioning] Error during provisioning. %s" % str(exp))
+
+        retries += 1
+        if retries >= max_retries:
+            break
+
+        sleep(randint(1, 5))
+        LOGGER.info("[ECC Provisioning] Retrying ...")
+
+    return provisioning_successful
 
 
 def did_gateway_mfr_test_result_include_miner_key_pass(

--- a/hm_pyhelper/tests/test_logger.py
+++ b/hm_pyhelper/tests/test_logger.py
@@ -9,7 +9,7 @@ class TestLogger(TestCase):
         logger = get_logger(__name__)
 
         with self.assertLogs() as captured:
-            logger.debug("Hello world.")
+            logger.info("Hello world.")
 
         # check that there is only one log message
         self.assertEqual(len(captured.records), 1)
@@ -20,7 +20,7 @@ class TestLogger(TestCase):
         # Do not check timestamp and filepath because those change
         # based on the environment and run time
         expected_partial_output_regex = re.escape(
-            " - [DEBUG] - hm_pyhelper.tests.test_logger -" +
+            " - [INFO] - hm_pyhelper.tests.test_logger -" +
             " (test_logger.py).test_get_logger -- ")
         expected_output_regex = ".*" + \
             expected_partial_output_regex + ".*" + \

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.17',
+    version='0.13.18',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
Added retry logic for ECC key provisioning and fixed a test case for testing the logger that was somehow broken as logging level by default is INFO and test was logging a DEBUG log message and expecting output in captured logs.

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests updated
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names