### PR TITLE
key generation backup logic and bugfix

### DIFF
--- a/hm_pyhelper/tests/test_miner_param.py
+++ b/hm_pyhelper/tests/test_miner_param.py
@@ -46,24 +46,17 @@ ALL_PASS_GATEWAY_MFR_TESTS = {
     'zone_locked(data)': {'checks': 'ok', 'result': 'pass'}
 }
 
+ERROR_MESSAGE = 'decode error\n\nCaused by:\n    not a compact key'
 
 NONE_PASS_GATEWAY_MFR_TESTS = {
-    'ecdh(0)': {
-        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
-    'key_config(0)': {
-        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
-    'miner_key(0)': {
-        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
-    'sign(0)': {
-        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
-    'slot_config(0)': {
-        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
-    'zone_locked(config)': {
-        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
-    'zone_locked(data)': {
-        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'}
+    'ecdh(0)': {'error': ERROR_MESSAGE, 'result': 'fail'},
+    'key_config(0)': {'error': ERROR_MESSAGE, 'result': 'fail'},
+    'miner_key(0)': {'error': ERROR_MESSAGE, 'result': 'fail'},
+    'sign(0)': {'error': ERROR_MESSAGE, 'result': 'fail'},
+    'slot_config(0)': {'error': ERROR_MESSAGE, 'result': 'fail'},
+    'zone_locked(config)': {'error': ERROR_MESSAGE, 'result': 'fail'},
+    'zone_locked(data)': {'error': ERROR_MESSAGE, 'result': 'fail'}
 }
-
 
 MOCK_VARIANT_DEFINITIONS = {
         'NEBHNT-WITH-ECC-ADDRESS': {

--- a/hm_pyhelper/tests/test_miner_param.py
+++ b/hm_pyhelper/tests/test_miner_param.py
@@ -13,71 +13,57 @@ from hm_pyhelper.miner_param import retry_get_region, await_spi_available, \
     get_mac_address, get_public_keys_rust, get_gateway_mfr_version, get_gateway_mfr_command
 
 
-ALL_PASS_GATEWAY_MFR_TESTS = [
-    {
-        "output": "ok",
-        "result": "pass",
-        "test": "serial"
+ALL_PASS_GATEWAY_MFR_TESTS = {
+    'ecdh(0)': {'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
+    'key_config(0)': {
+        'checks': {
+            'auth_key': '0',
+            'intrusion_disable': 'false',
+            'key_type': 'ecc',
+            'lockable': 'true',
+            'private': 'true',
+            'pub_info': 'true',
+            'req_auth': 'false',
+            'req_random': 'false',
+            'x509_index': '0'
+        },
+        'result': 'pass'
     },
-    {
-        "output": "ok",
-        "result": "pass",
-        "test": "zone_locked(data)"
+    'miner_key(0)': {'checks': 'ok', 'result': 'pass'},
+    'sign(0)': {'checks': 'ok', 'result': 'pass'},
+    'slot_config(0)': {
+        'checks': {
+            'ecdh_operation': 'true',
+            'encrypt_read': 'false',
+            'external_signatures': 'true',
+            'internal_signatures': 'true',
+            'limited_use': 'false',
+            'secret': 'true'
+        },
+        'result': 'pass'
     },
-    {
-        "output": "ok",
-        "result": "pass",
-        "test": "zone_locked(config)"
-    },
-    {
-        "output": "ok",
-        "result": "pass",
-        "test": "slot_config(0..=15, ecc)"
-    },
-    {
-        "output": "ok",
-        "result": "pass",
-        "test": "key_config(0..=15, ecc)"
-    },
-    {
-        "output": "ok",
-        "result": "pass",
-        "test": "miner_key(0)"
-    }
-]
+    'zone_locked(config)': {'checks': 'ok', 'result': 'pass'},
+    'zone_locked(data)': {'checks': 'ok', 'result': 'pass'}
+}
 
-NONE_PASS_GATEWAY_MFR_TESTS = [
-    {
-        "output": "timeout/retry error",
-        "result": "fail",
-        "test": "serial"
-    },
-    {
-        "output": "timeout/retry error",
-        "result": "fail",
-        "test": "zone_locked(data)"
-    },
-    {
-        "output": "timeout/retry error",
-        "result": "fail",
-        "test": "zone_locked(config)"
-    },
-    {
-        "output": "timeout/retry error",
-        "result": "fail",
-        "test": "slot_config(0..=15, ecc)"
-    },
-    {
-        "output": "timeout/retry error",
-        "result": "fail",
-        "test": "key_config(0..=15, ecc)"
-    },
-    {
-        "output": "timeout/retry error",
-        "result": "fail",
-        "test": "miner_key(0)"
-    }
-  ]
+
+NONE_PASS_GATEWAY_MFR_TESTS = {
+    'ecdh(0)': {
+        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
+    'key_config(0)': {
+        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
+    'miner_key(0)': {
+        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
+    'sign(0)': {
+        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
+    'slot_config(0)': {
+        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
+    'zone_locked(config)': {
+        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'},
+    'zone_locked(data)': {
+        'error': 'decode error\n\nCaused by:\n    not a compact key', 'result': 'fail'}
+}
+
 
 MOCK_VARIANT_DEFINITIONS = {
         'NEBHNT-WITH-ECC-ADDRESS': {
@@ -374,38 +360,7 @@ class TestMinerParam(unittest.TestCase):
     def test_did_gateway_mfr_test_result_include_miner_key_pass(self):
         get_gateway_mfr_test_result = {
             "result": "fail",
-            "tests": [
-                {
-                    "output": "timeout/retry error",
-                    "result": "fail",
-                    "test": "serial"
-                },
-                {
-                    "output": "timeout/retry error",
-                    "result": "fail",
-                    "test": "zone_locked(data)"
-                },
-                {
-                    "output": "timeout/retry error",
-                    "result": "fail",
-                    "test": "zone_locked(config)"
-                },
-                {
-                    "output": "timeout/retry error",
-                    "result": "fail",
-                    "test": "slot_config(0..=15, ecc)"
-                },
-                {
-                    "output": "timeout/retry error",
-                    "result": "fail",
-                    "test": "key_config(0..=15, ecc)"
-                },
-                {
-                    "output": "ok",
-                    "result": "pass",
-                    "test": "miner_key(0)"
-                }
-            ]
+            "tests": ALL_PASS_GATEWAY_MFR_TESTS
         }
         self.assertTrue(
                 did_gateway_mfr_test_result_include_miner_key_pass(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.34',
+    version='0.13.35',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Issue**

- Fixed code for new gateway_mfr result format
- Updated test cases for the new gateway_mfr (>0.2.0) version response format.
- Fixed provisioning being passed as list bug
- Added key generation logic as backup if key provisioning fails.


- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names