### PR TITLE
gateway-mfr-rs: Update to latest release v0.2.2

### DIFF
--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Fetch gateway-mfr-rs
         env:
-          GATEWAY_MFR_RS_RELEASE: v0.2.1
+          GATEWAY_MFR_RS_RELEASE: v0.2.2
         run: |
           wget "https://github.com/helium/gateway-mfr-rs/releases/download/${GATEWAY_MFR_RS_RELEASE}/gateway-mfr-${GATEWAY_MFR_RS_RELEASE}-arm-unknown-linux-gnueabihf.tar.gz"
           wget "https://github.com/helium/gateway-mfr-rs/releases/download/${GATEWAY_MFR_RS_RELEASE}/gateway-mfr-${GATEWAY_MFR_RS_RELEASE}-arm-unknown-linux-gnueabihf.checksum"

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Fetch gateway-mfr-rs
         env:
-          GATEWAY_MFR_RS_RELEASE: v0.2.1
+          GATEWAY_MFR_RS_RELEASE: v0.2.2
         run: |
           wget "https://github.com/helium/gateway-mfr-rs/releases/download/${GATEWAY_MFR_RS_RELEASE}/gateway-mfr-${GATEWAY_MFR_RS_RELEASE}-arm-unknown-linux-gnueabihf.tar.gz"
           wget "https://github.com/helium/gateway-mfr-rs/releases/download/${GATEWAY_MFR_RS_RELEASE}/gateway-mfr-${GATEWAY_MFR_RS_RELEASE}-arm-unknown-linux-gnueabihf.checksum"


### PR DESCRIPTION
Update gateway-mfr-rs to latest release v0.2.2
Ref https://github.com/helium/gateway-mfr-rs/releases/tag/v0.2.2