### PR TITLE
fix: remove unnecessary ECC lock and improve bus check

### DIFF
--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -148,7 +148,7 @@ def get_ecc_location() -> str:
                 return ecc_location
 
     if not ecc_location:
-        ecc_location = 'None'
+        ecc_location = None
         LOGGER.info("Can't find ECC. Ensure SWARM_KEY_URI is correct in hardware definitions.")
 
     return ecc_location

--- a/hm_pyhelper/miner_param.py
+++ b/hm_pyhelper/miner_param.py
@@ -116,8 +116,9 @@ def get_ecc_location() -> str:
     ecc_list = get_variant_attribute(os.getenv('VARIANT'), 'SWARM_KEY_URI')
 
     try:
-        with open("eccfile", 'r') as data:
+        with open("/var/nebra/ecc_file", 'r') as data:
             generated_ecc_location = str(data.read()).rstrip('\n')
+
         if len(generated_ecc_location) < 10:
             generated_ecc_location = None
         else:
@@ -142,9 +143,13 @@ def get_ecc_location() -> str:
 
             if config_search_param(command, parameter):
                 ecc_location = location
-                with open("eccfile", "w") as file:
+                with open("/var/nebra/ecc_file", "w") as file:
                     file.write(ecc_location)
                 return ecc_location
+
+    if not ecc_location:
+        ecc_location = 'None'
+        LOGGER.info("Can't find ECC. Ensure SWARM_KEY_URI is correct in hardware definitions.")
 
     return ecc_location
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='hm_pyhelper',
-    version='0.13.58',
+    version='0.13.59',
     author="Nebra Ltd",
     author_email="support@nebra.com",
     description="Helium Python Helper",


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/helium-syncrobit/issues/10
- Summary: remove unnecessary ECC lock and improve bus check

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

- ECC lock not required on this check because all we are doing is checking the i2c address of the attached device.
- persist a generated ECC location (from the i2c bus) to file to make get_ecc_location() function more efficient and to remove unnecessary calls to the i2c bus 
- additional tests for SWARM_KEY_URI_OVERRIDE and new "persist to file" feature

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Ref: https://github.com/NebraLtd/helium-syncrobit/issues/10
Ref: https://github.com/NebraLtd/helium-syncrobit/issues/2

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names