### PR TITLE
Fix publish-to-test-pypi workflow

### DIFF
--- a/.github/workflows/publish-to-pypi-test.yml
+++ b/.github/workflows/publish-to-pypi-test.yml
@@ -83,4 +83,4 @@ jobs:
         run: |
           poetry config pypi-token.test-pypi ${{ secrets.TEST_PYPI_API_TOKEN }}
           poetry config repositories.test-pypi https://test.pypi.org/legacy/
-          poetry publish
+          poetry publish -r test-pypi


### PR DESCRIPTION
**Issue**

The publish command in `publish-to-test-pypi` workflow is missing the `-r` argument to specify the test repo.

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names