### PR TITLE
Added hw definition for Heltec HT-M2808

### DIFF
--- a/hm_pyhelper/hardware_definitions.py
+++ b/hm_pyhelper/hardware_definitions.py
@@ -689,7 +689,29 @@ variant_definitions = {
         'CONTAINS_FCC_IDS': [],
         'IC_IDS': [],
         'CONTAINS_IC_IDS': []
-    },
+        },
+
+    # Heltec HT-M2808
+    'heltec-fl1': {
+        'FRIENDLY': 'Heltec HT-M2808 Hotspot',
+        'SUPPORTED_MODELS': ['Heltec HT-M2808'],
+        'CPU_ARCH': 'arm64',
+        'BALENA_DEVICE_TYPE': ['rockpro64'],
+        'SPIBUS': 'spidev32766.0',
+        'SWARM_KEY_URI': ['ecc://i2c-1:96?slot=0','ecc://i2c-4:96?slot=0'],
+        'ONBOARDING_KEY_URI': ['ecc://i2c-1:96?slot=0','ecc://i2c-4:96?slot=0'],
+        'RESET': 2,
+        'MAC': 'eth0',
+        'STATUS': 85,
+        'BUTTON': 83,
+        'ECCOB': True,
+        'TYPE': 'Full',
+        'CELLULAR': False,
+        'FCC_IDS': [],
+        'CONTAINS_FCC_IDS': [],
+        'IC_IDS': [],
+        'CONTAINS_IC_IDS': []
+        }
 }
 
 # Note: Maintain old names for backward compatibility, should be removed at some


### PR DESCRIPTION
**Issue**
Added hardware definition for Heltec HT-M2808.  The BalenaOS image is still under development (RK3328) so "rockpro64" is used as a placeholder.

**How**
Have been ruining a Heltec for several weeks using this hardware definition.  However, Heltec produced devices with different ECC chip types, including single-wire interface variants.  Unfortunately, these SWI variants interface to a GPIO pin instead of a UART.  To reliably use the chip, I wrote a kernel driver that mimics an I2C interface for it.  This would typically be available as i2c-4 device 0x60.  A standard I2C ECC variant of the Heltec has not been tested, but should present as i2c-1 device 0x60.

**References**
SWI ECC Driver: https://github.com/radicale/i2c-swi-gpio

**Checklist**

- [ ] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names